### PR TITLE
Add latency and error Alerts

### DIFF
--- a/internal/server/instrumentation.go
+++ b/internal/server/instrumentation.go
@@ -34,7 +34,7 @@ func newInstrumentationMiddleware(r prometheus.Registerer) *instrumentationMiddl
 			prometheus.HistogramOpts{
 				Name:    "http_request_duration_seconds",
 				Help:    "Histogram of latencies for HTTP requests.",
-				Buckets: []float64{.1, .2, .4, 1, 3, 8, 20, 60, 120},
+				Buckets: []float64{.1, .2, .4, 1, 2.5, 5, 8, 20, 60, 120},
 			},
 			[]string{"code", "handler", "method"},
 		),

--- a/jsonnet/alerts.jsonnet
+++ b/jsonnet/alerts.jsonnet
@@ -1,0 +1,3 @@
+(
+    (import 'mixin/alerts/alerts.libsonnet')
+).prometheusAlerts

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -18,7 +18,7 @@
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "24bb588b39b95f300e695aaf6db8c6cdc6c964b2"
+      "version": "afd4a7ebbe4515027d507f2fc24b2fc0b9154302"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -18,7 +18,7 @@
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "afd4a7ebbe4515027d507f2fc24b2fc0b9154302"
+      "version": "dab0b5e00378266567335044ad347d2d29d57274"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -1,14 +1,25 @@
 {
-    "dependencies": [
-        {
-            "name": "ksonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/ksonnet/ksonnet-lib",
-                    "subdir": ""
-                }
-            },
-            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib",
+          "subdir": ""
         }
-    ]
+      },
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
+      "name": "ksonnet"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/metalmatze/slo-libsonnet",
+          "subdir": "slo-libsonnet"
+        }
+      },
+      "version": "42a8a3e2dd14cc39add753e8bd8788eeb6d7ea39"
+    }
+  ],
+  "legacyImports": true
 }

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -18,7 +18,7 @@
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "42a8a3e2dd14cc39add753e8bd8788eeb6d7ea39"
+      "version": "24bb588b39b95f300e695aaf6db8c6cdc6c964b2"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -19,8 +19,8 @@
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "afd4a7ebbe4515027d507f2fc24b2fc0b9154302",
-      "sum": "TbxkmmkdQnlZT1cJ1+IvfdGvcLxeLJtaryOuuWwbv0g="
+      "version": "dab0b5e00378266567335044ad347d2d29d57274",
+      "sum": "5sosi7mw5FqnZkbSaAb8wacFU9qtbW5UU3s8aRgR3Ko="
     }
   ],
   "legacyImports": false

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -19,8 +19,8 @@
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "24bb588b39b95f300e695aaf6db8c6cdc6c964b2",
-      "sum": "c0RfCaaE1ZR4BclcEndOosHPpCCHhwvXDbQ7y+NTl/c="
+      "version": "afd4a7ebbe4515027d507f2fc24b2fc0b9154302",
+      "sum": "TbxkmmkdQnlZT1cJ1+IvfdGvcLxeLJtaryOuuWwbv0g="
     }
   ],
   "legacyImports": false

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -11,6 +11,16 @@
       "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
       "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg=",
       "name": "ksonnet"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/metalmatze/slo-libsonnet",
+          "subdir": "slo-libsonnet"
+        }
+      },
+      "version": "24bb588b39b95f300e695aaf6db8c6cdc6c964b2",
+      "sum": "c0RfCaaE1ZR4BclcEndOosHPpCCHhwvXDbQ7y+NTl/c="
     }
   ],
   "legacyImports": false

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -1,0 +1,20 @@
+local latency = import 'slo-libsonnet/latency-burn.libsonnet';
+
+{
+  local write = latency.burn({
+    metric: 'http_request_duration_seconds',
+    selectors: ['handler="write"'],
+    # How much responce delay is too much.
+    latencyTarget: "1",
+    # The 30 days SLO promise.
+    # When the promise is 99% that means that
+    # in 30d can only have 1% queries above the latencyTarget.
+    latencyBudget: 1-0.99,
+  }),
+
+  prometheusAlerts+:: {
+    // The actual output results.
+    recordingrule: write.recordingrules,
+    alerts: write.alerts,
+  }
+}

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -1,7 +1,7 @@
-local latency = import 'slo-libsonnet/latency-burn.libsonnet';
+local slo = import 'slo-libsonnet/latency-burn.libsonnet';
 
 {
-  local write = latency.burn({
+  local write = slo.latencyburn({
     metric: 'http_request_duration_seconds',
     selectors: ['handler="write"'],
     # How much responce delay is too much.


### PR DESCRIPTION
moved the jb jsonnet files in the jsonnet folder as otherwise jb install deletes everything in the root vendor dir.

to generate from within the jsonnet dir
`jsonnet -J vendor alerts.jsonnet | gojsontoyaml > http-request-latency-burnrate.yaml`

I will add  alerts for all endpoint in the same PR after you check this first one.

cc @kakkoyun , @metalmatze 

 - [ ] how to ensure the le bucket exists ? easy to add a selector for a non existing bucket
 - [ ] recording rules have duplicated names