### PR TITLE
Change URL Scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ CONTAINER_CMD:=docker run --rm \
 		quay.io/coreos/jsonnet-ci
 
 .PHONY: generate
-generate: jsonnet-vendor ${MANIFESTS}
+generate: jsonnet-vendor ${MANIFESTS} README.md
 
 .PHONY: generate-in-docker
 generate-in-docker:

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-dependencies: $(THANOS) $(UP) $(EMBEDMD) $(GOLANGCILINT) $(SHELLCHECK)
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
-$(THANOS): $(BIN_DIR)
+$(THANOS): | $(BIN_DIR)
 	@echo "Downloading Thanos"
 	curl -L "https://github.com/thanos-io/thanos/releases/download/v$(THANOS_VERSION)/thanos-$(THANOS_VERSION).$$(go env GOOS)-$$(go env GOARCH).tar.gz" | tar --strip-components=1 -xzf - -C $(BIN_DIR)
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ Usage of ./observatorium:
     	The log format to use. Options: 'logfmt', 'json'. (default "logfmt")
   -log.level string
     	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
+  -metrics.query-range.endpoint string
+    	The endpoint against which to query for metrics.
   -metrics.query.endpoint string
     	The endpoint against which to query for metrics.
+  -metrics.read.endpoint string
+    	The endpoint against which to send read requests for metrics. It used as a fallback to 'query.endpoint' and 'query-range.endpoint'.
   -metrics.ui.endpoint string
     	The endpoint which forward ui requests.
   -metrics.write.endpoint string

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ Usage of ./observatorium:
     	The log format to use. Options: 'logfmt', 'json'. (default "logfmt")
   -log.level string
     	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
-  -metrics.query-range.endpoint string
-    	The endpoint against which to query for metrics.
-  -metrics.query.endpoint string
-    	The endpoint against which to query for metrics.
   -metrics.read.endpoint string
     	The endpoint against which to send read requests for metrics. It used as a fallback to 'query.endpoint' and 'query-range.endpoint'.
   -metrics.ui.endpoint string

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - args:
         - --web.listen=0.0.0.0:8080
         - --metrics.ui.endpoint=http://127.0.0.1:9091/
-        - --metrics.query.endpoint=http://127.0.0.1:9091/api/v1/query
+        - --metrics.read.endpoint=http://127.0.0.1:9091/api/v1
         - --metrics.write.endpoint=http://127.0.0.1:19291/api/v1/receive
         - --log.level=warn
         image: quay.io/observatorium/observatorium:master-2020-01-28-e009b4a

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -57,12 +57,12 @@ func New(logger log.Logger, prefix string, endpoint *url.URL, opts ...Option) *P
 
 		level.Debug(logger).Log("scheme", r.URL.Scheme, "host", r.URL.Host, "path", r.URL.Path)
 	}
-	stdErrlogger := stdlog.New(log.NewStdlibAdapter(level.Error(logger)), "", stdlog.Lshortfile)
+	stdErrLogger := stdlog.New(log.NewStdlibAdapter(level.Error(logger)), "", stdlog.Lshortfile)
 
 	rev := httputil.ReverseProxy{
 		BufferPool:    bufferPool,
 		Director:      director,
-		ErrorLog:      stdErrlogger,
+		ErrorLog:      stdErrLogger,
 		FlushInterval: options.flushInterval,
 	}
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -49,11 +49,13 @@ func New(logger log.Logger, prefix string, endpoint *url.URL, opts ...Option) *P
 			r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 
+		level.Debug(logger).Log("endpoint scheme", endpoint.Scheme, "endpoint host", endpoint.Host, "prefix", prefix, "path", r.URL.Path)
+
 		r.URL.Scheme = endpoint.Scheme
 		r.URL.Host = endpoint.Host
 		r.URL.Path = path.Join(endpoint.Path, strings.TrimPrefix(r.URL.Path, prefix))
 
-		log.With(level.Debug(logger)).Log("scheme", r.URL.Scheme, "host", r.URL.Host, "path", r.URL.Path)
+		level.Debug(logger).Log("scheme", r.URL.Scheme, "host", r.URL.Host, "path", r.URL.Path)
 	}
 	stdErrlogger := stdlog.New(log.NewStdlibAdapter(level.Error(logger)), "", stdlog.Lshortfile)
 

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -8,15 +8,13 @@ import (
 )
 
 type options struct {
-	gracePeriod               time.Duration
-	timeout                   time.Duration
-	metricsReadEndpoint       *url.URL
-	metricsQueryEndpoint      *url.URL
-	metricsQueryRangeEndpoint *url.URL
-	metricsUIEndpoint         *url.URL
-	metricsWriteEndpoint      *url.URL
-	profile                   bool
-	listen                    string
+	gracePeriod          time.Duration
+	timeout              time.Duration
+	metricsUIEndpoint    *url.URL
+	metricsReadEndpoint  *url.URL
+	metricsWriteEndpoint *url.URL
+	profile              bool
+	listen               string
 
 	proxyOptions []proxy.Option
 }
@@ -57,20 +55,6 @@ func WithTimeout(t time.Duration) Option {
 func WithMetricReadEndpoint(u *url.URL) Option {
 	return optionFunc(func(o *options) {
 		o.metricsReadEndpoint = u
-	})
-}
-
-// WithMetricQueryEndpoint TODO
-func WithMetricQueryEndpoint(u *url.URL) Option {
-	return optionFunc(func(o *options) {
-		o.metricsQueryEndpoint = u
-	})
-}
-
-// WithMetricQueryEndpoint TODO
-func WithMetricQueryRangeEndpoint(u *url.URL) Option {
-	return optionFunc(func(o *options) {
-		o.metricsQueryRangeEndpoint = u
 	})
 }
 

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -8,13 +8,15 @@ import (
 )
 
 type options struct {
-	gracePeriod          time.Duration
-	timeout              time.Duration
-	metricsQueryEndpoint *url.URL
-	metricsUIEndpoint    *url.URL
-	metricsWriteEndpoint *url.URL
-	profile              bool
-	listen               string
+	gracePeriod               time.Duration
+	timeout                   time.Duration
+	metricsReadEndpoint       *url.URL
+	metricsQueryEndpoint      *url.URL
+	metricsQueryRangeEndpoint *url.URL
+	metricsUIEndpoint         *url.URL
+	metricsWriteEndpoint      *url.URL
+	profile                   bool
+	listen                    string
 
 	proxyOptions []proxy.Option
 }
@@ -51,10 +53,24 @@ func WithTimeout(t time.Duration) Option {
 	})
 }
 
+// WithMetricReadEndpoint TODO
+func WithMetricReadEndpoint(u *url.URL) Option {
+	return optionFunc(func(o *options) {
+		o.metricsReadEndpoint = u
+	})
+}
+
 // WithMetricQueryEndpoint TODO
 func WithMetricQueryEndpoint(u *url.URL) Option {
 	return optionFunc(func(o *options) {
 		o.metricsQueryEndpoint = u
+	})
+}
+
+// WithMetricQueryEndpoint TODO
+func WithMetricQueryRangeEndpoint(u *url.URL) Option {
+	return optionFunc(func(o *options) {
+		o.metricsQueryRangeEndpoint = u
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,22 +59,10 @@ func New(logger log.Logger, reg *prometheus.Registry, opts ...Option) Server {
 
 	namespace := "/api/metrics/v1"
 	r.Route(namespace, func(r chi.Router) {
-		if options.metricsQueryEndpoint != nil {
-			queryPath := "/api/v1/query"
-			r.Mount(queryPath,
-				ins.newHandler("query", proxy.New(logger, namespace+queryPath, options.metricsQueryEndpoint, options.proxyOptions...)))
-		}
-
-		if options.metricsQueryRangeEndpoint != nil {
-			queryRangePath := "/api/v1/query_range"
-			r.Mount(queryRangePath,
-				ins.newHandler("query_range", proxy.New(logger, namespace+queryRangePath, options.metricsQueryRangeEndpoint, options.proxyOptions...)))
-		}
-
 		if options.metricsReadEndpoint != nil {
 			readPath := "/api/v1/*"
 			r.Get(readPath,
-				ins.newHandler("read", proxy.New(logger, namespace+"/api/v1/", options.metricsReadEndpoint, options.proxyOptions...)))
+				ins.newHandler("read", proxy.New(logger, namespace+"/api/v1", options.metricsReadEndpoint, options.proxyOptions...)))
 		}
 
 		writePath := "/write"

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -10,7 +10,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     image: error 'must provide image',
     replicas: error 'must provide replicas',
     uiEndpoint: error 'must provide uiEndpoint',
-    queryEndpoint: error 'must provide queryEndpoint',
+    readEnpoint: error 'must provide readEnpoint',
     writeEndpoint: error 'must provide writeEndpoint',
 
     commonLabels:: {
@@ -51,7 +51,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       container.withArgs([
         '--web.listen=0.0.0.0:8080',
         '--metrics.ui.endpoint=' + gateway.config.uiEndpoint,
-        '--metrics.query.endpoint=' + gateway.config.queryEndpoint,
+        '--metrics.read.endpoint=' + gateway.config.readEndpoint,
         '--metrics.write.endpoint=' + gateway.config.writeEndpoint,
         '--log.level=warn',
       ]) +

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -7,7 +7,7 @@ local gateway = (import 'lib/observatorium-api.libsonnet') {
     image: 'quay.io/observatorium/observatorium:' + cfg.version,
     replicas: 3,
     uiEndpoint: 'http://127.0.0.1:9091/',
-    queryEndpoint: 'http://127.0.0.1:9091/api/v1/query',
+    readEndpoint: 'http://127.0.0.1:9091/api/v1',
     writeEndpoint: 'http://127.0.0.1:19291/api/v1/receive',
   },
 };

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -40,6 +40,7 @@ func (p *Prober) handler(check Check) http.HandlerFunc {
 			http.Error(w, "NOT OK", http.StatusServiceUnavailable)
 			return
 		}
+
 		if _, err := io.WriteString(w, "OK"); err != nil {
 			level.Error(p.logger).Log("msg", "failed to write probe response", "err", err)
 		}

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -13,8 +13,6 @@ trap 'kill $(jobs -p); exit $result' EXIT
     --web.listen=0.0.0.0:8080 \
     --metrics.ui.endpoint=http://127.0.0.1:9091/ \
     --metrics.read.endpoint=http://127.0.0.1:9091/api/v1 \
-    --metrics.query.endpoint=http://127.0.0.1:9091/api/v1/query \
-    --metrics.query-range.endpoint=http://127.0.0.1:9091/api/v1/query_range \
     --metrics.write.endpoint=http://127.0.0.1:19291/api/v1/receive \
     --log.level=debug
 ) &

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -34,7 +34,7 @@ trap 'kill $(jobs -p); exit $result' EXIT
     --http-address=127.0.0.1:9091 \
     --store=127.0.0.1:10901 \
     --log.level=debug \
-    --web.external-prefix=/metrics/ui/v1
+    --web.external-prefix=/ui/metrics/v1
 ) &
 
 echo "## waiting for dependencies to come up..."
@@ -42,8 +42,8 @@ sleep 5
 
 if ./tmp/bin/up \
   --listen=0.0.0.0:8888 \
-  --endpoint-read=http://127.0.0.1:8080/metrics/api/v1/query \
-  --endpoint-write=http://127.0.0.1:8080/metrics/api/v1/write \
+  --endpoint-read=http://127.0.0.1:8080/api/metrics/v1/api/v1/query \
+  --endpoint-write=http://127.0.0.1:8080/api/metrics/v1/write \
   --period=500ms \
   --initial-query-delay=250ms \
   --threshold=1 \

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -12,7 +12,9 @@ trap 'kill $(jobs -p); exit $result' EXIT
   ./observatorium \
     --web.listen=0.0.0.0:8080 \
     --metrics.ui.endpoint=http://127.0.0.1:9091/ \
+    --metrics.read.endpoint=http://127.0.0.1:9091/api/v1 \
     --metrics.query.endpoint=http://127.0.0.1:9091/api/v1/query \
+    --metrics.query-range.endpoint=http://127.0.0.1:9091/api/v1/query_range \
     --metrics.write.endpoint=http://127.0.0.1:19291/api/v1/receive \
     --log.level=debug
 ) &
@@ -32,7 +34,7 @@ trap 'kill $(jobs -p); exit $result' EXIT
     --http-address=127.0.0.1:9091 \
     --store=127.0.0.1:10901 \
     --log.level=debug \
-    --web.external-prefix=http://localhost:8080/ui/v1/metrics
+    --web.external-prefix=/metrics/ui/v1
 ) &
 
 echo "## waiting for dependencies to come up..."
@@ -40,8 +42,8 @@ sleep 5
 
 if ./tmp/bin/up \
   --listen=0.0.0.0:8888 \
-  --endpoint-read=http://127.0.0.1:8080/api/v1/metrics/query \
-  --endpoint-write=http://127.0.0.1:8080/api/v1/metrics/write \
+  --endpoint-read=http://127.0.0.1:8080/metrics/api/v1/query \
+  --endpoint-write=http://127.0.0.1:8080/metrics/api/v1/write \
   --period=500ms \
   --initial-query-delay=250ms \
   --threshold=1 \


### PR DESCRIPTION
This PR changes API URL scheme from `/api/v1/metrics/` to `/api/metrics/v1`, `{interface}/{domain}/{version}`

There are a couple of reasons that justify these changes:
* To be compatible with existing tools such as Prometheus client libraries, e,g `client_go` and Grafana
(These tools expect a base URL and they add paths such as `api/v1/query`)
* To change versions of domains independently, e.g `/api/metrics/v1` and `/api/logs/v3` 

This is a breaking change,  however, Observatorium API GW hasn't been used in production and released a stable version, so this change should be ok.

Resulting APIs that could be use from outside:
```
/api/metrics/v1/api/v1/query
/api/metrics/v1/api/v1/query_range
/api/metrics/v1/write
```

Fixes #9 , #15.

cc @brancz @metalmatze @krasi-georgiev 

# Changes

* Adds a new flags
  -  `--metrics.read.endpoint` fallback base URL for metrics read requests.
    - (Fallback read URL now used to proxy requests that have unrecognized paths directly to backing service.
* Removes `--metrics.query-range.endpoint`, a flag which was a proxy URL to forward query_range requests. It's not needed anymore.