### PR TITLE
Only trigger release job for SemVer tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,15 +63,6 @@ workflows:
       - lint
       - test
       - generate
-  tagged-master:
-    jobs:
-      - container-release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only:
-                - master
   commit-master:
     jobs:
       - build
@@ -85,3 +76,18 @@ workflows:
             branches:
               only:
                 - master
+  tagged-master:
+    jobs:
+      - container-release:
+          filters:
+            tags:
+              # v1.1.0
+              # v1.1.0-rc0
+              # v1.1.0-rc1
+              # v1.1.0-rc.0
+              # v1.1.0-rc.1
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-rc(\.)?([0-9]+))?$/
+            branches:
+              only:
+                - master
+                - /release-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,8 @@ workflows:
               # Suggested SemVer regex:
               # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
               # https://regex101.com/r/vkijKf/1/
-              only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+              # NOTICE: with an additional "v" as prefix.
+              only: /v^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
             branches:
               only:
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,10 @@ workflows:
       - container-release:
           filters:
             tags:
-              # v1.1.0
-              # v1.1.0-rc0
-              # v1.1.0-rc1
-              # v1.1.0-rc.0
-              # v1.1.0-rc.1
-              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-rc(\.)?([0-9]+))?$/
+              # Suggested SemVer regex:
+              # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+              # https://regex101.com/r/vkijKf/1/
+              only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
             branches:
               only:
                 - master

--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,11 @@ container-push: container
 	docker push $(DOCKER_REPO):latest
 
 .PHONY: container-release
+container-release: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --points-at HEAD))
 container-release: container
 	# https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---points-atltobjectgt
-	@docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):$(VERSION)
-	docker push $(DOCKER_REPO):$(strip $(shell [ -d .git ] && git tag --points-at HEAD))
+	@docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):$(VERSION_TAG)
+	docker push $(DOCKER_REPO):$(VERSION_TAG)
 	docker push $(DOCKER_REPO):latest
 
 .PHONY: integration-test-dependencies

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,9 @@ container-push: container
 
 .PHONY: container-release
 container-release: container
+	# https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---points-atltobjectgt
 	@docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):$(VERSION)
-	docker push $(DOCKER_REPO):$(VERSION)
+	docker push $(DOCKER_REPO):$(strip $(shell [ -d .git ] && git tag --points-at HEAD))
 	docker push $(DOCKER_REPO):latest
 
 .PHONY: integration-test-dependencies


### PR DESCRIPTION
### Changes
* Only trigger release job for SemVer tags

The job gets triggered for all master merges, we just want it to get triggered with tagged versions.
https://quay.io/repository/observatorium/observatorium?tag=latest&tab=tags