### PR TITLE
Add query and query_range as generic handlers forwarding all verbs

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,6 +69,16 @@ func New(logger log.Logger, reg *prometheus.Registry, opts ...Option) Server {
 		promhttp.InstrumentMetricHandler(reg, promhttp.HandlerFor(reg, promhttp.HandlerOpts{})).ServeHTTP(w, r)
 	})
 
+	{
+		// Legacy endpoints
+		r.Handle("/api/v1/query",
+			ins.newHandler("query_legacy", proxy.New(logger, "/api/v1", options.metricsReadEndpoint, options.proxyOptions...)),
+		)
+		r.Handle("/api/v1/query_range",
+			ins.newHandler("query_range_legacy", proxy.New(logger, "/api/v1", options.metricsReadEndpoint, options.proxyOptions...)),
+		)
+	}
+
 	if options.metricsUIEndpoint != nil {
 		uiPath := "/ui/metrics/v1"
 
@@ -92,10 +102,6 @@ func New(logger log.Logger, reg *prometheus.Registry, opts ...Option) Server {
 			})
 		}
 	}
-
-	r.Get("/api/v1/query",
-		ins.newHandler("query_legacy", proxy.New(logger, "/api/v1", options.metricsReadEndpoint, options.proxyOptions...)),
-	)
 
 	namespace := "/api/metrics/v1"
 	r.Route(namespace, func(r chi.Router) {


### PR DESCRIPTION
Next to adding the `/api/v1/query_range` endpoint too, the handlers are now simple handlers accepting every verb and then letting the downstream service decide on accepting or declining requests with specific verbs.

/cc @squat @kakkoyun @brancz 