### PR TITLE
Redirect to UI including query params

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,12 @@ func main() {
 		)
 
 		r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/api/metrics/v1/graph", http.StatusMovedPermanently)
+			r.URL.Path = "/api/metrics/v1/graph"
+			http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
+		})
+		r.HandleFunc("/graph", func(w http.ResponseWriter, r *http.Request) {
+			r.URL.Path = "/api/metrics/v1/graph"
+			http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
 		})
 
 		s := http.Server{


### PR DESCRIPTION
This is mostly so that in case people have bookmarked queries or there are links to graphs saved elsewhere still work and they get forwarded accordingly.

If someone has a bookmark / link to `graph?g0.range_input=1h&g0.max_source_resolution=0s&g0.expr=up&g0.tab=1` then going forward that will be redirected including the query parameters, so that those links don't break.

/cc @squat