### PR TITLE
.circleci: clean up config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,13 +57,7 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
-    jobs:
-      - build
-      - lint
-      - test
-      - generate
-  commit-master:
+  test-and-push:
     jobs:
       - build
       - lint


### PR DESCRIPTION
Currently, we run two workflows on every PR, build_and_test and
commit-master, both of which run all tests. This mistake was also
present in observatorium/configuration and was cleaned up in
https://github.com/observatorium/configuration/pull/241.

cc @metalmatze @kakkoyun 

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>