### PR TITLE
internal/authorization: create authz middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Usage of ./observatorium:
     	The name of the HTTP header containing the tenant ID to forward to the metrics upstreams. (default "THANOS-TENANT")
   -metrics.write.endpoint string
     	The endpoint against which to make write requests for metrics.
+  -rbac.config string
+    	Path to the RBAC configuration file. (default "rbac.yaml")
   -tenants.config string
     	Path to the tenants file. (default "tenants.yaml")
   -tls-cert-file string

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	google.golang.org/genproto v0.0.0-20200413115906-b5235f65be36 // indirect
-	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/component-base v0.18.0
 )
 

--- a/internal/authorization/http.go
+++ b/internal/authorization/http.go
@@ -1,0 +1,32 @@
+package authorization
+
+import (
+	"net/http"
+
+	"github.com/observatorium/observatorium/internal/authentication"
+	"github.com/observatorium/observatorium/rbac"
+)
+
+// WithAuthorizer returns a middleware that authorizes subjects taken from a request context
+// for the given permission on the given resource for a tenant taken from a request context.
+func WithAuthorizer(a rbac.Authorizer, permission rbac.Permission, resource string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tenant, ok := authentication.GetTenant(r.Context())
+			if !ok {
+				http.Error(w, "error finding tenant", http.StatusInternalServerError)
+				return
+			}
+			subject, ok := authentication.GetSubject(r.Context())
+			if !ok {
+				http.Error(w, "unknown subject", http.StatusUnauthorized)
+				return
+			}
+			if !a.Authorize(subject, permission, resource, tenant) {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/test/config/rbac.yaml
+++ b/test/config/rbac.yaml
@@ -1,0 +1,15 @@
+roles:
+- name: read-write
+  resources:
+  - metrics
+  tenants:
+  - test
+  permissions:
+  - read
+  - write
+roleBindings:
+- name: test
+  roles:
+  - read-write
+  subjects:
+  - admin@example.com

--- a/test/config/tenants.yaml
+++ b/test/config/tenants.yaml
@@ -2,7 +2,8 @@ tenants:
 - name: test
   id: 1610b0c3-c509-4592-a256-a1871353dbfa
   oidc:
-    clientID:     test
+    clientID: test
     clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
-    issuerURL:    http://127.0.0.1:5556/dex
-    redirectURL:  http://localhost:8080/oidc/test/callback
+    issuerURL: http://127.0.0.1:5556/dex
+    redirectURL: http://localhost:8080/oidc/test/callback
+    usernameClaim: email

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -20,10 +20,9 @@ token=$(curl --request POST \
     --data grant_type=password \
     --data username=admin@example.com \
     --data password=password \
-    --data audience=telemeter \
     --data client_id=test \
     --data client_secret=ZXhhbXBsZS1hcHAtc2VjcmV0  \
-    --data scope=openid | sed 's/^{.*"id_token":[^"]*"\([^"]*\)".*}/\1/')
+    --data scope="openid email" | sed 's/^{.*"id_token":[^"]*"\([^"]*\)".*}/\1/')
 
 (
   ./observatorium \
@@ -33,6 +32,7 @@ token=$(curl --request POST \
     --tls-private-key-file=./tmp/certs/server.key \
     --metrics.read.endpoint=http://127.0.0.1:9091 \
     --metrics.write.endpoint=http://127.0.0.1:19291 \
+    --rbac.config=./test/config/rbac.yaml \
     --tenants.config=./test/config/tenants.yaml \
     --log.level=debug
 ) &

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -512,7 +512,6 @@ gopkg.in/square/go-jose.v2
 gopkg.in/square/go-jose.v2/cipher
 gopkg.in/square/go-jose.v2/json
 # gopkg.in/yaml.v2 v2.2.8
-## explicit
 gopkg.in/yaml.v2
 # k8s.io/apimachinery v0.18.0
 k8s.io/apimachinery/pkg/util/sets


### PR DESCRIPTION
This commit implements and utilizes an authorization middleware to limit
API usage to subjects who have access to resources belonging to a
tenant, as specified in an RBAC configuration file.

At the heart of it, this commit simply ties the existing rbac.Authorizer
interface to a middleware. One implementation detail is that in order to
identify a subject, we need to find a username from the OIDC token. We
now allow the tenant to specify the field that should be used to
uniquely identify subjects, just as the Kubernetes apiserver does
with its `--oidc-username-claim` flag. The subject's name wil default to
the value of the `sub` field, but can be changed to, e.g., `email` in
order to have nicer usernames in RBAC role bindings.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze @brancz 