### PR TITLE
Add loki query and push proxy support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          apt-get update && apt-get install xz-utils
+          apt-get update && apt-get install xz-utils unzip
           make test --always-make
 
   generate:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ THANOS_VERSION ?= 0.12.2
 PROMETHEUS ?= $(BIN_DIR)/prometheus
 PROMETHEUS_VERSION ?= 2.15.2
 
+LOKI ?= $(BIN_DIR)/loki
+LOKI_VERSION ?= 1.5.0
+
 UP ?= $(BIN_DIR)/up
 DEX ?= $(BIN_DIR)/dex
 MOCKPROVIDER ?= $(BIN_DIR)/mockprovider
@@ -135,7 +138,8 @@ container-release: container
 	docker push $(DOCKER_REPO):latest
 
 .PHONY: integration-test-dependencies
-integration-test-dependencies: $(THANOS) $(UP) $(DEX)
+
+integration-test-dependencies: $(THANOS) $(UP) $(DEX) $(LOKI)
 
 .PHONY: load-test-dependencies
 load-test-dependencies: $(PROMREMOTEBENCH) $(PROMETHEUS) $(STYX) $(MOCKPROVIDER)
@@ -162,6 +166,14 @@ $(THANOS): | $(BIN_DIR)
 $(PROMETHEUS): | $(BIN_DIR)
 	@echo "Downloading Prometheus"
 	curl -L "https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$$(go env GOOS)-$$(go env GOARCH).tar.gz" | tar --strip-components=1 -xzf - -C $(BIN_DIR)
+
+$(LOKI): | $(BIN_DIR)
+	@echo "Downloading Loki"
+	(loki_pkg="loki-$$(go env GOOS)-$$(go env GOARCH)" && \
+	cd $(BIN_DIR) && curl -O -L "https://github.com/grafana/loki/releases/download/v$(LOKI_VERSION)/$$loki_pkg.zip" && \
+	unzip $$loki_pkg.zip && \
+	mv $$loki_pkg loki && \
+	rm $$loki_pkg.zip)
 
 $(UP): | vendor $(BIN_DIR)
 	go build -mod=vendor -o $@ github.com/observatorium/up

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Usage of ./observatorium:
     	The log format to use. Options: 'logfmt', 'json'. (default "logfmt")
   -log.level string
     	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
+  -logs.read.endpoint string
+    	The endpoint against which to make read requests for logs.
+  -logs.tenant-header string
+    	The name of the HTTP header containing the tenant ID to forward to the logs upstream. (default "X-Scope-OrgID")
+  -logs.write.endpoint string
+    	The endpoint against which to make write requests for logs.
   -metrics.read.endpoint string
     	The endpoint against which to send read requests for metrics. It used as a fallback to 'query.endpoint' and 'query-range.endpoint'.
   -metrics.tenant-header string

--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -6,8 +6,14 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
     version: 'master-2020-05-04-v0.1.1-21-gabb9864',
     image: 'quay.io/observatorium/observatorium:' + cfg.version,
     replicas: 3,
-    readEndpoint: 'http://127.0.0.1:9091',
-    writeEndpoint: 'http://127.0.0.1:19291',
+    metrics:{
+      readEndpoint: 'http://127.0.0.1:9091',
+      writeEndpoint: 'http://127.0.0.1:19291',
+    },
+    logs:{
+      readEndpoint: 'http://127.0.0.1:3100',
+      writeEndpoint: 'http://127.0.0.1:3100',
+    },
   },
 };
 

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -31,6 +31,8 @@ spec:
       - args:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
+        - --logs.read.endpoint=http://127.0.0.1:3100
+        - --logs.write.endpoint=http://127.0.0.1:3100
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291
         - --log.level=warn

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -31,6 +31,8 @@ spec:
       - args:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
+        - --logs.read.endpoint=http://127.0.0.1:3100
+        - --logs.write.endpoint=http://127.0.0.1:3100
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291
         - --log.level=warn

--- a/internal/api/logs/v1/http.go
+++ b/internal/api/logs/v1/http.go
@@ -1,0 +1,154 @@
+package http
+
+import (
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-kit/kit/log"
+	"github.com/observatorium/observatorium/internal/proxy"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	ReadTimeout        = 15 * time.Minute
+	WriteTimeout       = time.Minute
+	lokiUpstreamPrefix = "/loki"
+)
+
+type handlerConfiguration struct {
+	logger           log.Logger
+	registry         *prometheus.Registry
+	instrument       handlerInstrumenter
+	readMiddlewares  []func(http.Handler) http.Handler
+	writeMiddlewares []func(http.Handler) http.Handler
+}
+
+// HandlerOption modifies the handler's configuration
+type HandlerOption func(h *handlerConfiguration)
+
+// Logger add a custom logger for the handler to use.
+func Logger(logger log.Logger) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.logger = logger
+	}
+}
+
+// Registry adds a custom Prometheus registry for the handler to use.
+func Registry(r *prometheus.Registry) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.registry = r
+	}
+}
+
+// HandlerInstrumenter adds a custom HTTP handler instrument middleware for the handler to use.
+func HandlerInstrumenter(instrumenter handlerInstrumenter) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.instrument = instrumenter
+	}
+}
+
+// ReadMiddleware adds a middleware for all read operations.
+func ReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.readMiddlewares = append(h.readMiddlewares, m)
+	}
+}
+
+// WriteMiddleware adds a middleware for all write operations.
+func WriteMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.writeMiddlewares = append(h.writeMiddlewares, m)
+	}
+}
+
+type handlerInstrumenter interface {
+	NewHandler(labels prometheus.Labels, handler http.Handler) http.HandlerFunc
+}
+
+type nopInstrumentHandler struct{}
+
+func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.Handler) http.HandlerFunc {
+	return handler.ServeHTTP
+}
+
+func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
+	c := &handlerConfiguration{
+		logger:     log.NewNopLogger(),
+		registry:   prometheus.NewRegistry(),
+		instrument: nopInstrumentHandler{},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+
+	r := chi.NewRouter()
+
+	if read != nil {
+		var proxyRead http.Handler
+		{
+			read.Path = path.Join(read.Path, lokiUpstreamPrefix)
+			middlewares := proxy.Middlewares(
+				proxy.MiddlewareSetUpstream(read),
+				proxy.MiddlewareLogger(c.logger),
+				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-read"}),
+			)
+
+			proxyRead = &httputil.ReverseProxy{
+				Director: middlewares,
+				ErrorLog: proxy.Logger(c.logger),
+				Transport: &http.Transport{
+					DialContext: (&net.Dialer{
+						Timeout: ReadTimeout,
+					}).DialContext,
+				},
+			}
+		}
+		r.Group(func(r chi.Router) {
+			r.Use(c.readMiddlewares...)
+			r.Handle("/api/v1/query", c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "query"},
+				proxyRead,
+			))
+			r.Handle("/api/v1/query_range", c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "query_range"},
+				proxyRead,
+			))
+		})
+	}
+
+	if write != nil {
+		var proxyWrite http.Handler
+		{
+			write.Path = path.Join(write.Path, lokiUpstreamPrefix)
+			middlewares := proxy.Middlewares(
+				proxy.MiddlewareSetUpstream(write),
+				proxy.MiddlewareLogger(c.logger),
+				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-write"}),
+			)
+
+			proxyWrite = &httputil.ReverseProxy{
+				Director: middlewares,
+				ErrorLog: proxy.Logger(c.logger),
+				Transport: &http.Transport{
+					DialContext: (&net.Dialer{
+						Timeout: WriteTimeout,
+					}).DialContext,
+				},
+			}
+		}
+		r.Group(func(r chi.Router) {
+			r.Use(c.writeMiddlewares...)
+			r.Handle("/api/v1/push", c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "push"},
+				proxyWrite,
+			))
+		})
+	}
+
+	return r
+}

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -10,8 +10,16 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     image: error 'must provide image',
     replicas: error 'must provide replicas',
     uiEndpoint: error 'must provide uiEndpoint',
-    readEnpoint: error 'must provide readEnpoint',
-    writeEndpoint: error 'must provide writeEndpoint',
+
+    metrics: {
+      readEnpoint: error 'must provide metrics readEnpoint',
+      writeEndpoint: error 'must provide metrics writeEndpoint',
+    },
+
+    logs: {
+      readEnpoint: error 'must provide logs readEnpoint',
+      writeEndpoint: error 'must provide logs writeEndpoint',
+    },
 
     ports: {
       public: 8080,
@@ -61,8 +69,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       container.withArgs([
         '--web.listen=0.0.0.0:%s' % api.config.ports.public,
         '--web.internal.listen=0.0.0.0:%s' % api.config.ports.internal,
-        '--metrics.read.endpoint=' + api.config.readEndpoint,
-        '--metrics.write.endpoint=' + api.config.writeEndpoint,
+        '--logs.read.endpoint=' + api.config.logs.readEndpoint,
+        '--logs.write.endpoint=' + api.config.logs.writeEndpoint,
+        '--metrics.read.endpoint=' + api.config.metrics.readEndpoint,
+        '--metrics.write.endpoint=' + api.config.metrics.writeEndpoint,
         '--log.level=warn',
       ]) +
       container.withPorts([

--- a/test/config/loki.yml
+++ b/test/config/loki.yml
@@ -1,0 +1,36 @@
+auth_enabled: true
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+  - from: 2019-01-01
+    store: boltdb
+    object_store: filesystem
+    schema: v11
+    index:
+      prefix: index_
+      period: 168h
+
+storage_config:
+  boltdb:
+    directory: /tmp/loki/index
+
+  filesystem:
+    directory: /tmp/loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: false

--- a/test/config/rbac.yaml
+++ b/test/config/rbac.yaml
@@ -2,6 +2,7 @@ roles:
 - name: read-write
   resources:
   - metrics
+  - logs
   tenants:
   - test
   permissions:


### PR DESCRIPTION
This PR adds proxy support to Loki `/loki/api/v1/{query, query_range, push}` and `/ready` endpoints. In addition it extends the api gateway CLI parameters to declare a read and write endpoint for the Loki.