### PR TITLE
.circleci: fix tagged master job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,4 @@ workflows:
               # NOTICE: with an additional "v" as prefix. https://regex101.com/r/ZPwiYu/1
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
             branches:
-              only:
-                - master
-                - /release-.*/
+              ignore: /.*/


### PR DESCRIPTION
Currently, merging to master triggers the tagged-master job, because it
seems that CircleCI filters are ORed. This causes the Makefile to try to
tag a docker container with a trailing `:` since the Git tag is emtpy.
This commit changes the logic so that the tagged-master job is only
triggered on a valid SemVer tag.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun 