### PR TITLE
examples: add rbac example

### DIFF
--- a/examples/rbac/simple.yaml
+++ b/examples/rbac/simple.yaml
@@ -1,0 +1,15 @@
+roles:
+- name: read-write
+  resources:
+  - metrics
+  tenants:
+  - telemeter
+  permissions:
+  - read
+  - write
+roleBindings:
+- name: telemeter
+  roles:
+  - read-write
+  subjects:
+  - admin@example.com

--- a/examples/tenants/simple.yaml
+++ b/examples/tenants/simple.yaml
@@ -1,8 +1,9 @@
 tenants:
-  - name: telemeter
-    id: FB870BF3-9F3A-44FF-9BF7-D7A047A52F43
-    oidc:
-      clientID:     telemeter
-      clientSecret: ov7zikeipai4neih7Chahcae
-      issuerURL:    http://127.0.0.1:5556/dex
-      redirectURL:  http://localhost:8080/oidc/telemeter/callback
+- name: telemeter
+  id: FB870BF3-9F3A-44FF-9BF7-D7A047A52F43
+  oidc:
+    clientID: telemeter
+    clientSecret: ov7zikeipai4neih7Chahcae
+    issuerURL: http://127.0.0.1:5556/dex
+    redirectURL: http://localhost:8080/oidc/telemeter/callback
+    usernameClaim: email


### PR DESCRIPTION
This commit adds an example RBAC configuration and shows a new field in
the tenant configuration.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze 