### PR TITLE
main.go: clean up flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Observatorium API
 ```txt
 Usage of ./observatorium:
   -debug.block-profile-rate int
-    	The parameter controls the fraction of goroutine blocking events that are reported in the blocking profile. (default 10)
+    	The percentage of goroutine blocking events that are reported in the blocking profile. (default 10)
   -debug.mutex-profile-fraction int
-    	The parameter which controls the fraction of mutex contention events that are reported in the mutex profile. (default 10)
+    	The percentage of mutex contention events that are reported in the mutex profile. (default 10)
   -debug.name string
-    	The name to add as prefix to log lines. (default "observatorium")
+    	A name to add as a prefix to log lines. (default "observatorium")
   -log.format string
     	The log format to use. Options: 'logfmt', 'json'. (default "logfmt")
   -log.level string
@@ -40,17 +40,17 @@ Usage of ./observatorium:
   -tls-cipher-suites string
     	Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).If omitted, the default Go cipher suites will be used.Note that TLS 1.3 ciphersuites are not configurable.
   -tls-client-ca-file string
-    	File containing the TLS CA to verify clients against.If no client CA is specified, there won't be any client verification on server side.
+    	File containing the TLS CA against which to verify clients.If no client CA is specified, there won't be any client verification on server side.
   -tls-min-version string
     	Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS13")
   -tls-private-key-file string
     	File containing the default x509 private key matching --tls-cert-file. Leave blank to disable TLS.
   -tls-reload-interval duration
-    	The interval at which to watch for TLS certificate changes, by default set to 1 minute. (default 1m0s)
+    	The interval at which to watch for TLS certificate changes. (default 1m0s)
   -web.healthchecks.url string
-    	The URL on which public server runs and to run healthchecks against. (default "http://localhost:8080")
+    	The URL against which to run healthchecks. (default "http://localhost:8080")
   -web.internal.listen string
-    	The address on which internal server runs. (default ":8081")
+    	The address on which the internal server listens. (default ":8081")
   -web.listen string
-    	The address on which public server runs. (default ":8080")
+    	The address on which the public server listens. (default ":8080")
 ```


### PR DESCRIPTION
This commit simply cleans up the grammar for the flag descriptions.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze 