### PR TITLE
jsonnet,examples: add RBAC + tenants to manifests

### DIFF
--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -6,13 +6,56 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
     version: 'master-2020-05-04-v0.1.1-21-gabb9864',
     image: 'quay.io/observatorium/observatorium:' + cfg.version,
     replicas: 3,
-    metrics:{
+    metrics: {
       readEndpoint: 'http://127.0.0.1:9091',
       writeEndpoint: 'http://127.0.0.1:19291',
     },
-    logs:{
+    logs: {
       readEndpoint: 'http://127.0.0.1:3100',
       writeEndpoint: 'http://127.0.0.1:3100',
+    },
+    rbac: {
+      roles: [
+        {
+          name: 'read-write',
+          resources: [
+            'metrics',
+          ],
+          tenants: [
+            'telemeter',
+          ],
+          permissions: [
+            'read',
+            'write',
+          ],
+        },
+      ],
+      roleBindings: [
+        {
+          name: 'telemeter',
+          roles: [
+            'read-write',
+          ],
+          subjects: [
+            'admin@example.com',
+          ],
+        },
+      ],
+    },
+    tenants: {
+      tenants: [
+        {
+          name: 'telemeter',
+          id: 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+          oidc: {
+            clientID: 'telemeter',
+            clientSecret: 'ov7zikeipai4neih7Chahcae',
+            issuerURL: 'http://127.0.0.1:5556/dex',
+            redirectURL: 'http://localhost:8080/oidc/telemeter/callback',
+            usernameClaim: 'email',
+          },
+        },
+      ],
     },
   },
 };
@@ -27,5 +70,13 @@ local apiWithTLS = api + api.withTLS {
   },
 };
 
-{ [name]: api[name] for name in std.objectFields(api) } +
-{ ['%s-with-tls' % name]: apiWithTLS[name] for name in std.objectFields(api) }
+{
+  [name]: api[name]
+  for name in std.objectFields(api)
+  if api[name] != null
+} +
+{
+  ['%s-with-tls' % name]: apiWithTLS[name]
+  for name in std.objectFields(api)
+  if apiWithTLS[name] != null
+}

--- a/examples/manifests/configmap-with-tls.yaml
+++ b/examples/manifests/configmap-with-tls.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  rbac.yaml: |-
+    "roleBindings":
+    - "name": "telemeter"
+      "roles":
+      - "read-write"
+      "subjects":
+      - "admin@example.com"
+    "roles":
+    - "name": "read-write"
+      "permissions":
+      - "read"
+      - "write"
+      "resources":
+      - "metrics"
+      "tenants":
+      - "telemeter"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium-api
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/version: master-2020-05-04-v0.1.1-21-gabb9864
+  name: observatorium-api
+  namespace: observatorium

--- a/examples/manifests/configmap.yaml
+++ b/examples/manifests/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  rbac.yaml: |-
+    "roleBindings":
+    - "name": "telemeter"
+      "roles":
+      - "read-write"
+      "subjects":
+      - "admin@example.com"
+    "roles":
+    - "name": "read-write"
+      "permissions":
+      - "read"
+      - "write"
+      "resources":
+      - "metrics"
+      "tenants":
+      - "telemeter"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium-api
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/version: master-2020-05-04-v0.1.1-21-gabb9864
+  name: observatorium-api
+  namespace: observatorium

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -36,6 +36,8 @@ spec:
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291
         - --log.level=warn
+        - --rbac.config=/etc/observatorium/rbac.yaml
+        - --tenants.config=/etc/observatorium/tenants.yaml
         - --tls-cert-file=./tmp/certs/server.pem
         - --tls-private-key-file=./tmp/certs/ca.pem
         - --tls-client-ca-file=./tmp/certs/server.key
@@ -61,3 +63,19 @@ spec:
             port: 8081
             scheme: HTTP
           periodSeconds: 5
+        volumeMounts:
+        - mountPath: /etc/observatorium/rbac.yaml
+          name: rbac
+          readOnly: true
+          subPath: rbac.yaml
+        - mountPath: /etc/observatorium/tenants.yaml
+          name: tenants
+          readOnly: true
+          subPath: tenants.yaml
+      volumes:
+      - configMap:
+          name: observatorium-api
+        name: rbac
+      - name: tenants
+        secret:
+          name: observatorium-api

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291
         - --log.level=warn
+        - --rbac.config=/etc/observatorium/rbac.yaml
+        - --tenants.config=/etc/observatorium/tenants.yaml
         image: quay.io/observatorium/observatorium:master-2020-05-04-v0.1.1-21-gabb9864
         livenessProbe:
           failureThreshold: 10
@@ -57,3 +59,19 @@ spec:
             port: 8081
             scheme: HTTP
           periodSeconds: 5
+        volumeMounts:
+        - mountPath: /etc/observatorium/rbac.yaml
+          name: rbac
+          readOnly: true
+          subPath: rbac.yaml
+        - mountPath: /etc/observatorium/tenants.yaml
+          name: tenants
+          readOnly: true
+          subPath: tenants.yaml
+      volumes:
+      - configMap:
+          name: observatorium-api
+        name: rbac
+      - name: tenants
+        secret:
+          name: observatorium-api

--- a/examples/manifests/secret-with-tls.yaml
+++ b/examples/manifests/secret-with-tls.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium-api
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/version: master-2020-05-04-v0.1.1-21-gabb9864
+  name: observatorium-api
+  namespace: observatorium
+stringData:
+  tenants.yaml: |-
+    "tenants":
+    - "id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+      "name": "telemeter"
+      "oidc":
+        "clientID": "telemeter"
+        "clientSecret": "ov7zikeipai4neih7Chahcae"
+        "issuerURL": "http://127.0.0.1:5556/dex"
+        "redirectURL": "http://localhost:8080/oidc/telemeter/callback"
+        "usernameClaim": "email"

--- a/examples/manifests/secret.yaml
+++ b/examples/manifests/secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium-api
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/version: master-2020-05-04-v0.1.1-21-gabb9864
+  name: observatorium-api
+  namespace: observatorium
+stringData:
+  tenants.yaml: |-
+    "tenants":
+    - "id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+      "name": "telemeter"
+      "oidc":
+        "clientID": "telemeter"
+        "clientSecret": "ov7zikeipai4neih7Chahcae"
+        "issuerURL": "http://127.0.0.1:5556/dex"
+        "redirectURL": "http://localhost:8080/oidc/telemeter/callback"
+        "usernameClaim": "email"

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -26,6 +26,9 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       internal: 8081,
     },
 
+    rbac: {},
+    tenants: {},
+
     commonLabels:: {
       'app.kubernetes.io/name': 'observatorium-api',
       'app.kubernetes.io/instance': api.config.name,
@@ -74,7 +77,15 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         '--metrics.read.endpoint=' + api.config.metrics.readEndpoint,
         '--metrics.write.endpoint=' + api.config.metrics.writeEndpoint,
         '--log.level=warn',
-      ]) +
+      ] + (
+        if api.config.rbac != {} then
+          ['--rbac.config=/etc/observatorium/rbac.yaml']
+        else []
+      ) + (
+        if api.config.tenants != {} then
+          ['--tenants.config=/etc/observatorium/tenants.yaml']
+        else []
+      )) +
       container.withPorts([
         containerPort.newNamed(api.config.ports[name], name)
         for name in std.objectFields(api.config.ports)
@@ -90,14 +101,80 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       container.mixin.readinessProbe.withFailureThreshold(12) +
       container.mixin.readinessProbe.httpGet.withPort(api.config.ports.internal) +
       container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
-      container.mixin.readinessProbe.httpGet.withPath('/ready');
+      container.mixin.readinessProbe.httpGet.withPath('/ready') +
+      if api.config.rbac != {} || api.config.tenants != {} then
+        container.withVolumeMounts(
+          (if api.config.rbac != {} then [
+             {
+               name: 'rbac',
+               mountPath: '/etc/observatorium/rbac.yaml',
+               subPath: 'rbac.yaml',
+               readOnly: true,
+             },
+           ] else []) +
+          (if api.config.tenants != {} then [
+             {
+               name: 'tenants',
+               mountPath: '/etc/observatorium/tenants.yaml',
+               subPath: 'tenants.yaml',
+               readOnly: true,
+             },
+           ] else [])
+        ) else {};
 
     deployment.new(api.config.name, api.config.replicas, c, api.config.commonLabels) +
     deployment.mixin.metadata.withNamespace(api.config.namespace) +
     deployment.mixin.metadata.withLabels(api.config.commonLabels) +
     deployment.mixin.spec.selector.withMatchLabels(api.config.podLabelSelector) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    if api.config.rbac != {} || api.config.tenants != {} then
+      deployment.mixin.spec.template.spec.withVolumes(
+        (if api.config.rbac != {} then [
+           {
+             configMap: {
+               name: api.config.name,
+             },
+             name: 'rbac',
+           },
+         ] else []) +
+        (if api.config.tenants != {} then [
+           {
+             secret: {
+               name: api.config.name,
+             },
+             name: 'tenants',
+           },
+         ] else [])
+      ) else {},
+
+  configmap:
+    if api.config.rbac != {} then {
+      apiVersion: 'v1',
+      data: {
+        'rbac.yaml': std.manifestYamlDoc(api.config.rbac),
+      },
+      kind: 'ConfigMap',
+      metadata: {
+        labels: api.config.commonLabels,
+        name: api.config.name,
+        namespace: api.config.namespace,
+      },
+    } else null,
+
+  secret:
+    if api.config.tenants != {} then {
+      apiVersion: 'v1',
+      stringData: {
+        'tenants.yaml': std.manifestYamlDoc(api.config.tenants),
+      },
+      kind: 'Secret',
+      metadata: {
+        labels: api.config.commonLabels,
+        name: api.config.name,
+        namespace: api.config.namespace,
+      },
+    } else null,
 
   withServiceMonitor:: {
     local api = self,


### PR DESCRIPTION
This PR adds RBAC and tenants configuration files to the generated
manifests by extending the jsonnet library for the API.

cc @metalmatze @periklis