### PR TITLE
Process cmd line arguments in generate-tls-cert

### DIFF
--- a/test/tls/generate.go
+++ b/test/tls/generate.go
@@ -45,6 +45,7 @@ func main() {
 	flag.DurationVar(&serverExpiration, "server-duration", defaultConfig.Expiry, "")
 	flag.StringVar(&clientCommonName, "client-common-name", "up", "")
 	flag.DurationVar(&clientExpiration, "client-duration", defaultConfig.Expiry, "")
+	flag.Parse()
 
 	caBundle, err := generateCACert(caCommonName)
 	if err != nil {


### PR DESCRIPTION
This patch adds a missing call to Parse()[1],
so cmd line arguments will get processed, making
the created certificates valid for additional use cases.

Issue: #54

[1] https://gobyexample.com/command-line-flags