### PR TITLE
Change default TLS version to VersionTLS12

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Usage of ./observatorium:
   -tls-client-ca-file string
     	File containing the TLS CA against which to verify clients.If no client CA is specified, there won't be any client verification on server side.
   -tls-min-version string
-    	Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS13")
+    	Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS12")
   -tls-private-key-file string
     	File containing the default x509 private key matching --tls-cert-file. Leave blank to disable TLS.
   -tls-reload-interval duration

--- a/main.go
+++ b/main.go
@@ -427,7 +427,7 @@ func parseFlags() (config, error) {
 	flag.StringVar(&cfg.tls.clientCAFile, "tls-client-ca-file", "",
 		"File containing the TLS CA against which to verify clients."+
 			"If no client CA is specified, there won't be any client verification on server side.")
-	flag.StringVar(&cfg.tls.minVersion, "tls-min-version", "VersionTLS13",
+	flag.StringVar(&cfg.tls.minVersion, "tls-min-version", "VersionTLS12",
 		"Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	flag.StringVar(&rawTLSCipherSuites, "tls-cipher-suites", "",
 		"Comma-separated list of cipher suites for the server."+


### PR DESCRIPTION
When configuring Prometheus Remote Write with TLS to send to
Observatorium API, we get the following error:

 `http: TLS handshake error from 10.128.0.248:54642: tls: client offered only unsupported versions: [303 302 301]`