### PR TITLE
test/integration.sh: use up to test logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ $(LOKI): | $(BIN_DIR)
 	rm $$loki_pkg.zip)
 
 $(UP): | vendor $(BIN_DIR)
-	go build -mod=vendor -o $@ github.com/observatorium/up
+	go build -mod=vendor -o $@ github.com/observatorium/up/cmd/up
 
 $(DEX): | vendor $(BIN_DIR)
 	go build -mod=vendor -o $@ github.com/dexidp/dex/cmd/dex

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
 	github.com/jsonnet-bundler/jsonnet-bundler v0.3.1
 	github.com/metalmatze/signal v0.0.0-20200428133549-c4243ecaf121
-	github.com/observatorium/up v0.0.0-20200515164021-716e0b4731a7
+	github.com/observatorium/up v0.0.0-20200603110215-8a20b4e48ac0
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
-github.com/observatorium/up v0.0.0-20200515164021-716e0b4731a7 h1:sFg4l0RmM2/eM4JlB5Vojvmyh1Mjpn9xjgq8NCj+Yng=
-github.com/observatorium/up v0.0.0-20200515164021-716e0b4731a7/go.mod h1:ysto9FMxd/1rHh9N9l1JfHLjT3X7ix4oWjMfnyrpqsY=
+github.com/observatorium/up v0.0.0-20200603110215-8a20b4e48ac0 h1:tbkKJiQkVbGfz7hEm3L+8HLEl7ZFzPuM9CNOVodQsmo=
+github.com/observatorium/up v0.0.0-20200603110215-8a20b4e48ac0/go.mod h1:ysto9FMxd/1rHh9N9l1JfHLjT3X7ix4oWjMfnyrpqsY=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=

--- a/tools.go
+++ b/tools.go
@@ -10,5 +10,5 @@ import (
 	_ "github.com/google/go-jsonnet/cmd/jsonnet"
 	_ "github.com/google/go-jsonnet/cmd/jsonnetfmt"
 	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"
-	_ "github.com/observatorium/up"
+	_ "github.com/observatorium/up/cmd/up"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,9 +205,15 @@ github.com/metalmatze/signal/internalserver
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/observatorium/up v0.0.0-20200515164021-716e0b4731a7
+# github.com/observatorium/up v0.0.0-20200603110215-8a20b4e48ac0
 ## explicit
-github.com/observatorium/up
+github.com/observatorium/up/cmd/up
+github.com/observatorium/up/pkg/auth
+github.com/observatorium/up/pkg/instr
+github.com/observatorium/up/pkg/logs
+github.com/observatorium/up/pkg/metrics
+github.com/observatorium/up/pkg/options
+github.com/observatorium/up/pkg/transport
 # github.com/oklog/run v1.1.0
 ## explicit
 github.com/oklog/run


### PR DESCRIPTION
This commit bumps the up tool to test logs ingestion thanks to
@periklis's recent updates in
https://github.com/observatorium/up/pull/16.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @metalmatze @periklis