### PR TITLE
Add TLS support to Healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,24 @@ Usage of ./observatorium:
     	Path to the RBAC configuration file. (default "rbac.yaml")
   -tenants.config string
     	Path to the tenants file. (default "tenants.yaml")
-  -tls-cert-file string
-    	File containing the default x509 Certificate for HTTPS. Leave blank to disable TLS.
-  -tls-cipher-suites string
+  -tls.cipher-suites string
     	Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).If omitted, the default Go cipher suites will be used.Note that TLS 1.3 ciphersuites are not configurable.
-  -tls-client-ca-file string
-    	File containing the TLS CA against which to verify clients.If no client CA is specified, there won't be any client verification on server side.
-  -tls-min-version string
+  -tls.healthchecks.cert-file string
+    	File containing the x509 client certificate for HTTPS healthchecks. Provide for healthchecks to use TLS.
+  -tls.healthchecks.key-file string
+    	File containing the x509 private key matching --tls.healthchecks.cert-file. Provide for healthchecks to use TLS.
+  -tls.healthchecks.server-ca-file string
+    	File containing the TLS CA against which to verify servers.If no server CA is specified, the client will use the system certificates.
+  -tls.min-version string
     	Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS13")
-  -tls-private-key-file string
-    	File containing the default x509 private key matching --tls-cert-file. Leave blank to disable TLS.
-  -tls-reload-interval duration
+  -tls.reload-interval duration
     	The interval at which to watch for TLS certificate changes. (default 1m0s)
+  -tls.server.cert-file string
+    	File containing the default x509 Certificate for HTTPS. Leave blank to disable TLS.
+  -tls.server.client-ca-file string
+    	File containing the TLS CA against which to verify clients.If no client CA is specified, there won't be any client verification on server side.
+  -tls.server.key-file string
+    	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
   -web.healthchecks.url string
     	The URL against which to run healthchecks. (default "http://localhost:8080")
   -web.internal.listen string

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-jsonnet v0.15.1-0.20200310221949-724650d358b6
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
 	github.com/jsonnet-bundler/jsonnet-bundler v0.3.1
-	github.com/metalmatze/signal v0.0.0-20200428133549-c4243ecaf121
+	github.com/metalmatze/signal v0.0.0-20200616171423-be84551ba3ce
 	github.com/observatorium/up v0.0.0-20200603110215-8a20b4e48ac0
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/metalmatze/signal v0.0.0-20200428133549-c4243ecaf121 h1:RUWzr2Jd0MWPA+hWmcrAdMLMhq+wyfFxvNtF9ecAEPY=
-github.com/metalmatze/signal v0.0.0-20200428133549-c4243ecaf121/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
+github.com/metalmatze/signal v0.0.0-20200616171423-be84551ba3ce h1:SXX/VQdzzAgUE+6qKFKni7Sx1ndbC0JWEtSxv9wyp7E=
+github.com/metalmatze/signal v0.0.0-20200616171423-be84551ba3ce/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -28,9 +28,14 @@ token=$(curl --request POST \
 (
   ./observatorium \
     --web.listen=0.0.0.0:8443 \
-    --tls-cert-file=./tmp/certs/server.pem \
-    --tls-client-ca-file=./tmp/certs/ca.pem \
-    --tls-private-key-file=./tmp/certs/server.key \
+    --web.internal.listen=0.0.0.0:8448 \
+    --web.healthchecks.url=https://localhost:8443 \
+    --tls.server.client-ca-file=./tmp/certs/ca.pem \
+    --tls.server.cert-file=./tmp/certs/server.pem \
+    --tls.server.key-file=./tmp/certs/server.key \
+    --tls.healthchecks.cert-file=./tmp/certs/client.pem \
+    --tls.healthchecks.key-file=./tmp/certs/client.key \
+    --tls.healthchecks.server-ca-file=./tmp/certs/ca.pem \
     --logs.read.endpoint=http://127.0.0.1:3100 \
     --logs.write.endpoint=http://127.0.0.1:3100 \
     --metrics.read.endpoint=http://127.0.0.1:9091 \
@@ -69,6 +74,11 @@ token=$(curl --request POST \
 
 printf "\t## waiting for dependencies to come up..."
 sleep 10
+
+until curl --output /dev/null --silent --fail http://localhost:8448/ready; do
+    printf '.'
+    sleep 1
+done
 
 echo "-------------------------------------------"
 echo "- Metrics tests                           -"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -197,7 +197,7 @@ github.com/mattn/go-isatty
 github.com/mattn/go-sqlite3
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/metalmatze/signal v0.0.0-20200428133549-c4243ecaf121
+# github.com/metalmatze/signal v0.0.0-20200616171423-be84551ba3ce
 ## explicit
 github.com/metalmatze/signal/healthcheck
 github.com/metalmatze/signal/internalserver


### PR DESCRIPTION
The healthchecks from the internal server weren't supporting HTTPS calls to the public server.
We can now explicitly pass `tls.healthchecks.*` via TLS configuration flags.

/cc @squat @nmagnezi
