### PR TITLE
api-deployment manifest handling for volumes and volumeMounts

### DIFF
--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -60,19 +60,24 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
   },
 };
 
-local apiWithTLS = api + api.withTLS {
+local apiWithTLS = api + {
   config+:: {
     tls+: {
-      certFile: './tmp/certs/server.pem',
-      privateKeyFile: './tmp/certs/server.key',
+      secret: {
+        certFile: '/mnt/certs/server.pem',
+        privateKeyFile: '/mnt/certs/server.key',
+        reloadInterval: '1m',
+      },
     },
   },
 };
 
-local withMTLS = apiWithTLS + api.withMTLS {
+local withMTLS = apiWithTLS + {
   config+:: {
-    tls+: {
-      clientCAFile: './tmp/certs/ca.pem',
+    mtls+: {
+      configMap: {
+        clientCAFile: '/mnt/clientca/ca.pem',
+      },
     },
   },
 };

--- a/examples/manifests/deployment-with-mtls.yaml
+++ b/examples/manifests/deployment-with-mtls.yaml
@@ -38,10 +38,10 @@ spec:
         - --log.level=warn
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
-        - --tls-cert-file=./tmp/certs/server.pem
-        - --tls-private-key-file=./tmp/certs/server.key
+        - --tls-cert-file=/mnt/certs/server.pem
+        - --tls-private-key-file=/mnt/certs/server.key
         - --tls-reload-interval=1m
-        - --tls-client-ca-file=./tmp/certs/ca.pem
+        - --tls-client-ca-file=/mnt/clientca/ca.pem
         image: quay.io/observatorium/observatorium:master-2020-05-04-v0.1.1-21-gabb9864
         livenessProbe:
           failureThreshold: 10
@@ -72,6 +72,12 @@ spec:
           name: tenants
           readOnly: true
           subPath: tenants.yaml
+        - mountPath: /mnt/certs
+          name: certs
+          readOnly: true
+        - mountPath: /mnt/clientca
+          name: client-ca
+          readOnly: true
       volumes:
       - configMap:
           name: observatorium-api
@@ -79,3 +85,9 @@ spec:
       - name: tenants
         secret:
           secretName: observatorium-api
+      - name: certs
+        secret:
+          secretName: observatorium-api-tls-certs
+      - configMap:
+          name: observatorium-api-tls-client-ca
+        name: client-ca

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -38,8 +38,8 @@ spec:
         - --log.level=warn
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
-        - --tls-cert-file=./tmp/certs/server.pem
-        - --tls-private-key-file=./tmp/certs/server.key
+        - --tls-cert-file=/mnt/certs/server.pem
+        - --tls-private-key-file=/mnt/certs/server.key
         - --tls-reload-interval=1m
         image: quay.io/observatorium/observatorium:master-2020-05-04-v0.1.1-21-gabb9864
         livenessProbe:
@@ -71,6 +71,9 @@ spec:
           name: tenants
           readOnly: true
           subPath: tenants.yaml
+        - mountPath: /mnt/certs
+          name: certs
+          readOnly: true
       volumes:
       - configMap:
           name: observatorium-api
@@ -78,3 +81,6 @@ spec:
       - name: tenants
         secret:
           secretName: observatorium-api
+      - name: certs
+        secret:
+          secretName: observatorium-api-tls-certs


### PR DESCRIPTION
 The reason for this change is that the operator cannot modify or append settings to existing manifests. It merely builds the config by squashing CR provided config and default config and invoke manifest generation.

The meaning of this is that the `api-deployment` manifest generator to be “smarter” and be able to append anything related to TLS settings when those are provided by the user (either manually in `config` or CR when driven by an operator).


