### PR TITLE
Add tail endpoint for logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          apt-get update && apt-get install xz-utils unzip
+          apt-get update && apt-get -y install xz-utils unzip openssl
           make test --always-make
 
   generate:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ PROMETHEUS_VERSION ?= 2.15.2
 
 LOKI ?= $(BIN_DIR)/loki
 LOKI_VERSION ?= 1.5.0
+WEBSOCAT ?= $(BIN_DIR)/websocat
+WEBSOCAT_VERSION ?= 1.5.0
+WEBSOCAT_PKG =
+ifeq ($(shell go env GOOS),linux)
+	WEBSOCAT_PKG = "websocat_amd64-linux"
+else
+	WEBSOCAT_PKG = "websocat_mac"
+endif
 
 UP ?= $(BIN_DIR)/up
 DEX ?= $(BIN_DIR)/dex
@@ -139,7 +147,7 @@ container-release: container
 
 .PHONY: integration-test-dependencies
 
-integration-test-dependencies: $(THANOS) $(UP) $(DEX) $(LOKI)
+integration-test-dependencies: $(THANOS) $(UP) $(DEX) $(LOKI) $(WEBSOCAT)
 
 .PHONY: load-test-dependencies
 load-test-dependencies: $(PROMREMOTEBENCH) $(PROMETHEUS) $(STYX) $(MOCKPROVIDER)
@@ -174,6 +182,12 @@ $(LOKI): | $(BIN_DIR)
 	unzip $$loki_pkg.zip && \
 	mv $$loki_pkg loki && \
 	rm $$loki_pkg.zip)
+
+$(WEBSOCAT): | $(BIN_DIR)
+	@echo "Downloading Websocat"
+	cd $(BIN_DIR) && curl -O -L "https://github.com/vi/websocat/releases/download/v$(WEBSOCAT_VERSION)/$(WEBSOCAT_PKG)" && \
+	mv $(WEBSOCAT_PKG) websocat && \
+	chmod u+x websocat
 
 $(UP): | vendor $(BIN_DIR)
 	go build -mod=vendor -o $@ github.com/observatorium/up/cmd/up

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Usage of ./observatorium:
     	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
   -logs.read.endpoint string
     	The endpoint against which to make read requests for logs.
+  -logs.tail.endpoint string
+    	The endpoint against which to make tail read requests for logs.
   -logs.tenant-header string
     	The name of the HTTP header containing the tenant ID to forward to the logs upstream. (default "X-Scope-OrgID")
   -logs.write.endpoint string

--- a/test/config/loki.yml
+++ b/test/config/loki.yml
@@ -14,6 +14,11 @@ ingester:
   chunk_idle_period: 5m
   chunk_retain_period: 30s
 
+querier:
+  engine:
+    max_look_back_period: 5m
+    timeout: 3m
+
 schema_config:
   configs:
   - from: 2019-01-01


### PR DESCRIPTION
This PR addresses a Loki specific distinction between read and tail requests. Read requests target the query frontend that is backed by the queriers and handles read concurrency and caching. Howeve, tail requests target the queriers directly.

**Reference:** [Grafana Gateway Configuration](https://github.com/grafana/loki/blob/master/production/ksonnet/loki/gateway.libsonnet#L43)

/cc @squat 