### PR TITLE
internal/authentication: enable mTLS auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ Usage of ./observatorium:
     	Path to the tenants file. (default "tenants.yaml")
   -tls.cipher-suites string
     	Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).If omitted, the default Go cipher suites will be used.Note that TLS 1.3 ciphersuites are not configurable.
-  -tls.healthchecks.cert-file string
-    	File containing the x509 client certificate for HTTPS healthchecks. Provide for healthchecks to use TLS.
-  -tls.healthchecks.key-file string
-    	File containing the x509 private key matching --tls.healthchecks.cert-file. Provide for healthchecks to use TLS.
   -tls.healthchecks.server-ca-file string
     	File containing the TLS CA against which to verify servers.If no server CA is specified, the client will use the system certificates.
   -tls.min-version string
@@ -88,8 +84,6 @@ Usage of ./observatorium:
     	The interval at which to watch for TLS certificate changes. (default 1m0s)
   -tls.server.cert-file string
     	File containing the default x509 Certificate for HTTPS. Leave blank to disable TLS.
-  -tls.server.client-ca-file string
-    	File containing the TLS CA against which to verify clients.If no client CA is specified, there won't be any client verification on server side.
   -tls.server.key-file string
     	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
   -web.healthchecks.url string

--- a/internal/authentication/http.go
+++ b/internal/authentication/http.go
@@ -2,14 +2,9 @@ package authentication
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"strings"
-	"time"
 
-	"github.com/coreos/go-oidc"
 	"github.com/go-chi/chi"
-	"golang.org/x/oauth2"
 )
 
 // contextKey to use when setting context values in the HTTP package.
@@ -22,7 +17,6 @@ func (c contextKey) String() string {
 }
 
 const (
-	state = "I love Observatorium"
 	// subjectKey is the key that holds the subject in a request context.
 	subjectKey contextKey = "subject"
 	// tenantKey is the key that holds the tenant in a request context.
@@ -66,47 +60,16 @@ func GetSubject(ctx context.Context) (string, bool) {
 	return subject, ok
 }
 
-type OIDCConfig struct {
-	Tenant        string
-	IssuerURL     string
-	ClientID      string
-	ClientSecret  string
-	RedirectURL   string
-	UsernameClaim string
-}
-
-type Middleware func(http.Handler) http.Handler
-
-func NewOIDCHandler(configs ...OIDCConfig) (http.Handler, Middleware, error) {
-	handlers := map[string]http.Handler{}
+// WithTenantMiddlewares creates a single Middleware for all
+// provided tenant-middleware sets.
+func WithTenantMiddlewares(middlewareSets ...map[string]Middleware) Middleware {
 	middlewares := map[string]Middleware{}
-
-	for _, c := range configs {
-		h, m, err := newProvider(c)
-		if err != nil {
-			return nil, nil, err
+	for _, ms := range middlewareSets {
+		for t, m := range ms {
+			middlewares[t] = m
 		}
-
-		handlers[c.Tenant] = h
-		middlewares[c.Tenant] = m
 	}
-
-	r := chi.NewRouter()
-	r.Mount("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tenant, ok := GetTenant(r.Context())
-		if !ok {
-			http.Error(w, "error finding tenant", http.StatusInternalServerError)
-			return
-		}
-		h, ok := handlers[tenant]
-		if !ok {
-			http.Error(w, "error finding tenant", http.StatusUnauthorized)
-			return
-		}
-		h.ServeHTTP(w, r)
-	}))
-
-	m := func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tenant, ok := GetTenant(r.Context())
 			if !ok {
@@ -122,150 +85,4 @@ func NewOIDCHandler(configs ...OIDCConfig) (http.Handler, Middleware, error) {
 			m(next).ServeHTTP(w, r)
 		})
 	}
-
-	return r, m, nil
-}
-
-func newProvider(config OIDCConfig) (http.Handler, Middleware, error) {
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	provider, err := oidc.NewProvider(context.TODO(), config.IssuerURL)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var s struct {
-		// What scopes does a provider support?
-		//
-		// See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
-		ScopesSupported []string `json:"scopes_supported"`
-	}
-
-	if err := provider.Claims(&s); err != nil {
-		return nil, nil, err
-	}
-
-	verifier := provider.Verifier(&oidc.Config{ClientID: config.ClientID})
-
-	oauth2Config := oauth2.Config{
-		ClientID:     config.ClientID,
-		ClientSecret: config.ClientSecret,
-		Endpoint:     provider.Endpoint(),
-		RedirectURL:  config.RedirectURL,
-		Scopes:       []string{"openid", "profile", "email"},
-	}
-
-	m := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var token string
-
-			authorizationHeader := r.Header.Get("Authorization")
-			if authorizationHeader != "" {
-				authorization := strings.Split(authorizationHeader, " ")
-				if len(authorization) != 2 {
-					http.Error(w, "invalid Authorization header", http.StatusUnauthorized)
-					return
-				}
-
-				token = authorization[1]
-			} else {
-				cookie, err := r.Cookie(getCookieForTenant(config.Tenant))
-				if err != nil {
-					http.Error(w, "failed to find token", http.StatusUnauthorized)
-					return
-				}
-				token = cookie.Value
-			}
-
-			idToken, err := verifier.Verify(r.Context(), token)
-			if err != nil {
-				http.Error(w, "failed to authenticate", http.StatusBadRequest)
-				return
-			}
-
-			sub := idToken.Subject
-			if config.UsernameClaim != "" {
-				claims := make(map[string]interface{})
-				if err := idToken.Claims(&claims); err != nil {
-					http.Error(w, "failed to read claims", http.StatusInternalServerError)
-					return
-				}
-				rawUsername, ok := claims[config.UsernameClaim]
-				if !ok {
-					http.Error(w, "username cannot be empty", http.StatusBadRequest)
-					return
-				}
-				username, ok := rawUsername.(string)
-				if !ok || username == "" {
-					http.Error(w, "invalid username claim value", http.StatusBadRequest)
-					return
-				}
-				sub = username
-			}
-
-			next.ServeHTTP(w, r.WithContext(
-				context.WithValue(r.Context(), subjectKey, sub),
-			))
-		})
-	}
-
-	r := chi.NewRouter()
-	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
-		url := oauth2Config.AuthCodeURL(state)
-		http.Redirect(w, r, url, http.StatusSeeOther)
-	})
-
-	r.Get("/callback", func(w http.ResponseWriter, r *http.Request) {
-		ctx := oidc.ClientContext(r.Context(), client)
-
-		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-			desc := r.URL.Query().Get("error_description")
-			http.Error(w, fmt.Sprintf("%s: %s", errMsg, desc), http.StatusBadRequest)
-			return
-		}
-
-		queryCode := r.URL.Query().Get("code")
-		if queryCode == "" {
-			http.Error(w, "no code in request", http.StatusBadRequest)
-			return
-		}
-		queryState := r.URL.Query().Get("state")
-		if queryState != state {
-			http.Error(w, "incorrect state in request", http.StatusBadRequest)
-			return
-		}
-
-		token, err := oauth2Config.Exchange(ctx, queryCode)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to get token: %v", err), http.StatusInternalServerError)
-			return
-		}
-
-		rawIDToken, ok := token.Extra("id_token").(string)
-		if !ok {
-			http.Error(w, "no id_token in token response", http.StatusInternalServerError)
-			return
-		}
-
-		_, err = verifier.Verify(r.Context(), rawIDToken)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to verify ID token: %v", err), http.StatusInternalServerError)
-			return
-		}
-
-		http.SetCookie(w, &http.Cookie{
-			Name:    getCookieForTenant(config.Tenant),
-			Value:   rawIDToken,
-			Path:    "/",
-			Expires: token.Expiry,
-		})
-
-		http.Redirect(w, r, "/"+config.Tenant, http.StatusFound)
-	})
-
-	return r, m, nil
-}
-
-func getCookieForTenant(tenant string) string {
-	return fmt.Sprintf("observatorium_%s", tenant)
 }

--- a/internal/authentication/mtls.go
+++ b/internal/authentication/mtls.go
@@ -1,0 +1,69 @@
+package authentication
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"net/http"
+)
+
+// MTLSConfig represents the mTLS configuration for a single tenant.
+type MTLSConfig struct {
+	Tenant string
+	CA     *x509.Certificate
+}
+
+// NewMTLS creates a set of Middlewares for all specified tenants.
+func NewMTLS(configs ...MTLSConfig) map[string]Middleware {
+	middlewares := map[string]Middleware{}
+
+	for _, c := range configs {
+		middlewares[c.Tenant] = func(next http.Handler) http.Handler {
+			caPool := x509.NewCertPool()
+			caPool.AddCert(c.CA)
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if len(r.TLS.PeerCertificates) == 0 {
+					http.Error(w, "no client certificate presented", http.StatusUnauthorized)
+					return
+				}
+				opts := x509.VerifyOptions{
+					Roots:         caPool,
+					Intermediates: x509.NewCertPool(),
+					KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				}
+				if len(r.TLS.PeerCertificates) > 1 {
+					for _, cert := range r.TLS.PeerCertificates[1:] {
+						opts.Intermediates.AddCert(cert)
+					}
+				}
+				if _, err := r.TLS.PeerCertificates[0].Verify(opts); err != nil {
+					if errors.Is(err, x509.CertificateInvalidError{}) {
+						http.Error(w, err.Error(), http.StatusUnauthorized)
+						return
+					}
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				var sub string
+				switch {
+				case len(r.TLS.PeerCertificates[0].EmailAddresses) > 0:
+					sub = r.TLS.PeerCertificates[0].EmailAddresses[0]
+				case len(r.TLS.PeerCertificates[0].URIs) > 0:
+					sub = r.TLS.PeerCertificates[0].URIs[0].String()
+				case len(r.TLS.PeerCertificates[0].DNSNames) > 0:
+					sub = r.TLS.PeerCertificates[0].DNSNames[0]
+				case len(r.TLS.PeerCertificates[0].IPAddresses) > 0:
+					sub = r.TLS.PeerCertificates[0].IPAddresses[0].String()
+				default:
+					http.Error(w, "could not determine subject", http.StatusBadRequest)
+					return
+				}
+				next.ServeHTTP(w, r.WithContext(
+					context.WithValue(r.Context(), subjectKey, sub),
+				))
+			})
+		}
+	}
+
+	return middlewares
+}

--- a/internal/authentication/oidc.go
+++ b/internal/authentication/oidc.go
@@ -1,0 +1,209 @@
+package authentication
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc"
+	"github.com/go-chi/chi"
+	"golang.org/x/oauth2"
+)
+
+const (
+	state = "I love Observatorium"
+)
+
+// OIDCConfig represents the OIDC configuration for a single tenant.
+type OIDCConfig struct {
+	Tenant        string
+	IssuerURL     string
+	ClientID      string
+	ClientSecret  string
+	RedirectURL   string
+	UsernameClaim string
+}
+
+// Middleware is a convenience type for functions that wrap http.Handlers.
+type Middleware func(http.Handler) http.Handler
+
+// NewOIDC creates a single http.Handler and a set of Middlewares for all
+// tenants that is able to authenticate requests and provide the
+// authorization code grant flow for users.
+func NewOIDC(configs ...OIDCConfig) (http.Handler, map[string]Middleware, error) {
+	handlers := map[string]http.Handler{}
+	middlewares := map[string]Middleware{}
+
+	for _, c := range configs {
+		h, m, err := newProvider(c)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		handlers[c.Tenant] = h
+		middlewares[c.Tenant] = m
+	}
+
+	r := chi.NewRouter()
+	r.Mount("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tenant, ok := GetTenant(r.Context())
+		if !ok {
+			http.Error(w, "error finding tenant", http.StatusInternalServerError)
+			return
+		}
+		h, ok := handlers[tenant]
+		if !ok {
+			http.Error(w, "error finding tenant", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, r)
+	}))
+
+	return r, middlewares, nil
+}
+
+func newProvider(config OIDCConfig) (http.Handler, Middleware, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	provider, err := oidc.NewProvider(context.TODO(), config.IssuerURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var s struct {
+		// What scopes does a provider support?
+		//
+		// See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+		ScopesSupported []string `json:"scopes_supported"`
+	}
+
+	if err := provider.Claims(&s); err != nil {
+		return nil, nil, err
+	}
+
+	verifier := provider.Verifier(&oidc.Config{ClientID: config.ClientID})
+
+	oauth2Config := oauth2.Config{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  config.RedirectURL,
+		Scopes:       []string{"openid", "profile", "email"},
+	}
+
+	m := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var token string
+
+			authorizationHeader := r.Header.Get("Authorization")
+			if authorizationHeader != "" {
+				authorization := strings.Split(authorizationHeader, " ")
+				if len(authorization) != 2 {
+					http.Error(w, "invalid Authorization header", http.StatusUnauthorized)
+					return
+				}
+
+				token = authorization[1]
+			} else {
+				cookie, err := r.Cookie(getCookieForTenant(config.Tenant))
+				if err != nil {
+					http.Error(w, "failed to find token", http.StatusUnauthorized)
+					return
+				}
+				token = cookie.Value
+			}
+
+			idToken, err := verifier.Verify(r.Context(), token)
+			if err != nil {
+				http.Error(w, "failed to authenticate", http.StatusBadRequest)
+				return
+			}
+
+			sub := idToken.Subject
+			if config.UsernameClaim != "" {
+				claims := map[string]interface{}{}
+				if err := idToken.Claims(&claims); err != nil {
+					http.Error(w, "failed to read claims", http.StatusInternalServerError)
+					return
+				}
+				rawUsername, ok := claims[config.UsernameClaim]
+				if !ok {
+					http.Error(w, "username cannot be empty", http.StatusBadRequest)
+					return
+				}
+				username, ok := rawUsername.(string)
+				if !ok || username == "" {
+					http.Error(w, "invalid username claim value", http.StatusBadRequest)
+					return
+				}
+				sub = username
+			}
+
+			next.ServeHTTP(w, r.WithContext(
+				context.WithValue(r.Context(), subjectKey, sub),
+			))
+		})
+	}
+
+	r := chi.NewRouter()
+	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		url := oauth2Config.AuthCodeURL(state)
+		http.Redirect(w, r, url, http.StatusSeeOther)
+	})
+
+	r.Get("/callback", func(w http.ResponseWriter, r *http.Request) {
+		ctx := oidc.ClientContext(r.Context(), client)
+
+		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+			desc := r.URL.Query().Get("error_description")
+			http.Error(w, fmt.Sprintf("%s: %s", errMsg, desc), http.StatusBadRequest)
+			return
+		}
+
+		queryCode := r.URL.Query().Get("code")
+		if queryCode == "" {
+			http.Error(w, "no code in request", http.StatusBadRequest)
+			return
+		}
+		queryState := r.URL.Query().Get("state")
+		if queryState != state {
+			http.Error(w, "incorrect state in request", http.StatusBadRequest)
+			return
+		}
+
+		token, err := oauth2Config.Exchange(ctx, queryCode)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to get token: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		rawIDToken, ok := token.Extra("id_token").(string)
+		if !ok {
+			http.Error(w, "no id_token in token response", http.StatusInternalServerError)
+			return
+		}
+
+		_, err = verifier.Verify(r.Context(), rawIDToken)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to verify ID token: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		http.SetCookie(w, &http.Cookie{
+			Name:    getCookieForTenant(config.Tenant),
+			Value:   rawIDToken,
+			Path:    "/",
+			Expires: token.Expiry,
+		})
+
+		http.Redirect(w, r, "/"+config.Tenant, http.StatusFound)
+	})
+
+	return r, m, nil
+}
+
+func getCookieForTenant(tenant string) string {
+	return fmt.Sprintf("observatorium_%s", tenant)
+}

--- a/test/config/rbac.yaml
+++ b/test/config/rbac.yaml
@@ -1,16 +1,30 @@
 roles:
-- name: read-write
+- name: read-write-oidc
   resources:
   - metrics
   - logs
   tenants:
-  - test
+  - test-oidc
+  permissions:
+  - read
+  - write
+- name: read-write-mtls
+  resources:
+  - metrics
+  - logs
+  tenants:
+  - test-mtls
   permissions:
   - read
   - write
 roleBindings:
-- name: test
+- name: test-oidc
   roles:
-  - read-write
+  - read-write-oidc
   subjects:
   - admin@example.com
+- name: test-mtls
+  roles:
+  - read-write-mtls
+  subjects:
+  - up

--- a/test/config/tenants.yaml
+++ b/test/config/tenants.yaml
@@ -1,5 +1,5 @@
 tenants:
-- name: test
+- name: test-oidc
   id: 1610b0c3-c509-4592-a256-a1871353dbfa
   oidc:
     clientID: test
@@ -7,3 +7,7 @@ tenants:
     issuerURL: http://127.0.0.1:5556/dex
     redirectURL: http://localhost:8080/oidc/test/callback
     usernameClaim: email
+- name: test-mtls
+  id: 845cdfd9-f936-443c-979c-2ee7dc91f646
+  mTLS:
+    caPath: ./tmp/certs/ca.pem


### PR DESCRIPTION
Currently, the Observatorium API has overlapping authentication
concepts:
* the API has a global mTLS setting to validate client certs; and
* each tenant can authenticate clients via OIDC.

It is confusing and messy that these overlap. Identify should be
mediated entirely by the mechanism chosen by the tenant and the API's
TLS configuration should provide a secure transport.

This commit removes the global mTLS settings of the API and enables
mTLS-based authentication on a per-tenant basis.
This means that each tenant can specify a separate CA to authenticate
all requests for resources they own.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers 