### PR TITLE
Add logs tail endpoint to deployment manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ In order to handle requests for logs, a compatible backend must be configured.
 The backend from which to read logs can be specified with the `--logs.read.endpoint` flag.
 Compatible backends must implement the Loki read API, e.g. Loki.
 
+#### --logs.tail.endpoint
+
+The backend from which to tail logs can be specified with the `--logs.tail.endpoint` flag.
+Compatible backends must implement the Loki tail API, e.g. Loki.
+
 #### --logs.write.endpoint
 
 The backend to which to write logs can be specified with the `--logs.write.endpoint` flag.

--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -12,6 +12,7 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
     },
     logs: {
       readEndpoint: 'http://127.0.0.1:3100',
+      tailEndpoint: 'http://127.0.0.1:3100',
       writeEndpoint: 'http://127.0.0.1:3100',
     },
     rbac: {

--- a/examples/manifests/deployment-with-mtls.yaml
+++ b/examples/manifests/deployment-with-mtls.yaml
@@ -32,6 +32,7 @@ spec:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
         - --logs.read.endpoint=http://127.0.0.1:3100
+        - --logs.tail.endpoint=http://127.0.0.1:3100
         - --logs.write.endpoint=http://127.0.0.1:3100
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -32,6 +32,7 @@ spec:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
         - --logs.read.endpoint=http://127.0.0.1:3100
+        - --logs.tail.endpoint=http://127.0.0.1:3100
         - --logs.write.endpoint=http://127.0.0.1:3100
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
         - --logs.read.endpoint=http://127.0.0.1:3100
+        - --logs.tail.endpoint=http://127.0.0.1:3100
         - --logs.write.endpoint=http://127.0.0.1:3100
         - --metrics.read.endpoint=http://127.0.0.1:9091
         - --metrics.write.endpoint=http://127.0.0.1:19291

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -17,6 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
     logs: {
       readEnpoint: error 'must provide logs readEnpoint',
+      tailEnpoint: error 'must provide logs tailEnpoint',
       writeEndpoint: error 'must provide logs writeEndpoint',
     },
 
@@ -74,6 +75,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         '--web.listen=0.0.0.0:%s' % api.config.ports.public,
         '--web.internal.listen=0.0.0.0:%s' % api.config.ports.internal,
         '--logs.read.endpoint=' + api.config.logs.readEndpoint,
+        '--logs.tail.endpoint=' + api.config.logs.tailEndpoint,
         '--logs.write.endpoint=' + api.config.logs.writeEndpoint,
         '--metrics.read.endpoint=' + api.config.metrics.readEndpoint,
         '--metrics.write.endpoint=' + api.config.metrics.writeEndpoint,


### PR DESCRIPTION
This PR addresses the missing jsonnet manifests for support the logs tail endpoint in #70 

cc @squat 