### PR TITLE
internal,rbac: enable groups in rbac

### DIFF
--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -38,7 +38,10 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
             'read-write',
           ],
           subjects: [
-            'admin@example.com',
+            {
+              name: 'admin@example.com',
+              kind: 'user',
+            },
           ],
         },
       ],

--- a/examples/manifests/configmap-with-tls.yaml
+++ b/examples/manifests/configmap-with-tls.yaml
@@ -6,7 +6,8 @@ data:
       "roles":
       - "read-write"
       "subjects":
-      - "admin@example.com"
+      - "kind": "user"
+        "name": "admin@example.com"
     "roles":
     - "name": "read-write"
       "permissions":

--- a/examples/manifests/configmap.yaml
+++ b/examples/manifests/configmap.yaml
@@ -6,7 +6,8 @@ data:
       "roles":
       - "read-write"
       "subjects":
-      - "admin@example.com"
+      - "kind": "user"
+        "name": "admin@example.com"
     "roles":
     - "name": "read-write"
       "permissions":

--- a/internal/authentication/http.go
+++ b/internal/authentication/http.go
@@ -17,6 +17,8 @@ func (c contextKey) String() string {
 }
 
 const (
+	// groupsKey is the key that holds the groups in a request context.
+	groupsKey contextKey = "groups"
 	// subjectKey is the key that holds the subject in a request context.
 	subjectKey contextKey = "subject"
 	// tenantKey is the key that holds the tenant in a request context.
@@ -58,6 +60,14 @@ func GetSubject(ctx context.Context) (string, bool) {
 	subject, ok := value.(string)
 
 	return subject, ok
+}
+
+// GetGroups extracts the groups from provided context.
+func GetGroups(ctx context.Context) ([]string, bool) {
+	value := ctx.Value(groupsKey)
+	groups, ok := value.([]string)
+
+	return groups, ok
 }
 
 // WithTenantMiddlewares creates a single Middleware for all

--- a/internal/authentication/mtls.go
+++ b/internal/authentication/mtls.go
@@ -58,9 +58,12 @@ func NewMTLS(configs ...MTLSConfig) map[string]Middleware {
 					http.Error(w, "could not determine subject", http.StatusBadRequest)
 					return
 				}
-				next.ServeHTTP(w, r.WithContext(
-					context.WithValue(r.Context(), subjectKey, sub),
-				))
+				ctx := context.WithValue(r.Context(), subjectKey, sub)
+
+				// Add organizational units as groups.
+				ctx = context.WithValue(ctx, groupsKey, r.TLS.PeerCertificates[0].Subject.OrganizationalUnit)
+
+				next.ServeHTTP(w, r.WithContext(ctx))
 			})
 		}
 	}

--- a/internal/authorization/http.go
+++ b/internal/authorization/http.go
@@ -22,7 +22,11 @@ func WithAuthorizer(a rbac.Authorizer, permission rbac.Permission, resource stri
 				http.Error(w, "unknown subject", http.StatusUnauthorized)
 				return
 			}
-			if !a.Authorize(subject, permission, resource, tenant) {
+			groups, ok := authentication.GetGroups(r.Context())
+			if !ok {
+				groups = []string{}
+			}
+			if !a.Authorize(subject, groups, permission, resource, tenant) {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func main() {
 		OIDC *struct {
 			ClientID      string `json:"clientID"`
 			ClientSecret  string `json:"clientSecret"`
+			GroupClaim    string `json:"groupClaim"`
 			IssuerURL     string `json:"issuerURL"`
 			RedirectURL   string `json:"redirectURL"`
 			UsernameClaim string `json:"usernameClaim"`
@@ -270,6 +271,7 @@ func main() {
 						Tenant:        t.Name,
 						ClientID:      t.OIDC.ClientID,
 						ClientSecret:  t.OIDC.ClientSecret,
+						GroupClaim:    t.OIDC.GroupClaim,
 						IssuerURL:     t.OIDC.IssuerURL,
 						RedirectURL:   t.OIDC.RedirectURL,
 						UsernameClaim: t.OIDC.UsernameClaim,

--- a/rbac/rbac_test.go
+++ b/rbac/rbac_test.go
@@ -6,6 +6,7 @@ import "testing"
 func TestNewAuthorizer(t *testing.T) {
 	type io struct {
 		subject    string
+		groups     []string
 		permission Permission
 		resource   string
 		tenant     string
@@ -124,12 +125,12 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "erika-a",
 					Roles:    []string{"a-write"},
-					Subjects: []string{"erika"},
+					Subjects: []Subject{{Name: "erika", Kind: User}},
 				},
 				{
 					Name:     "max-a",
 					Roles:    []string{"b-write"},
-					Subjects: []string{"max"},
+					Subjects: []Subject{{Name: "max", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -162,7 +163,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "a-b",
 					Roles:    []string{"a-b-write"},
-					Subjects: []string{"erika", "max"},
+					Subjects: []Subject{{Name: "erika", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -209,7 +210,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "erika-a",
 					Roles:    []string{"a-write"},
-					Subjects: []string{"erika"},
+					Subjects: []Subject{{Name: "erika", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -270,7 +271,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "erika-a",
 					Roles:    []string{"a-write"},
-					Subjects: []string{"erika"},
+					Subjects: []Subject{{Name: "erika", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -331,7 +332,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "erika-a",
 					Roles:    []string{"rw"},
-					Subjects: []string{"erika"},
+					Subjects: []Subject{{Name: "erika", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -399,7 +400,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "a",
 					Roles:    []string{"writer"},
-					Subjects: []string{"erika", "max"},
+					Subjects: []Subject{{Name: "erika", Kind: User}, {Name: "max", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -460,7 +461,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "a",
 					Roles:    []string{"writer"},
-					Subjects: []string{"erika", "max"},
+					Subjects: []Subject{{Name: "erika", Kind: User}, {Name: "max", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -528,7 +529,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "b",
 					Roles:    []string{"reader"},
-					Subjects: []string{"erika", "max"},
+					Subjects: []Subject{{Name: "erika", Kind: User}, {Name: "max", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -610,7 +611,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "a-b",
 					Roles:    []string{"reader", "writer"},
-					Subjects: []string{"erika", "max"},
+					Subjects: []Subject{{Name: "erika", Kind: User}, {Name: "max", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -679,7 +680,7 @@ func TestNewAuthorizer(t *testing.T) {
 				{
 					Name:     "a-b",
 					Roles:    []string{"rw"},
-					Subjects: []string{"erika", "max"},
+					Subjects: []Subject{{Name: "erika", Kind: User}, {Name: "max", Kind: User}},
 				},
 			},
 			ios: []io{
@@ -734,11 +735,163 @@ func TestNewAuthorizer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "group mustermann read for a",
+			roles: []Role{
+				{
+					Name:        "a-read",
+					Resources:   []string{"foo"},
+					Tenants:     []string{"a"},
+					Permissions: []Permission{"read"},
+				},
+			},
+			roleBindings: []RoleBinding{
+				{
+					Name:     "mustermann-a",
+					Roles:    []string{"a-read"},
+					Subjects: []Subject{{Name: "mustermann", Kind: Group}},
+				},
+			},
+			ios: []io{
+				{
+					subject:    "erika",
+					groups:     []string{"mustermann"},
+					permission: Read,
+					resource:   "foo",
+					tenant:     "a",
+					output:     true,
+				},
+				{
+					subject:    "erika",
+					groups:     []string{"mustermann"},
+					permission: Write,
+					resource:   "foo",
+					tenant:     "a",
+					output:     false,
+				},
+				{
+					subject:    "erika",
+					groups:     []string{"mustermann"},
+					permission: Read,
+					resource:   "foo",
+					tenant:     "b",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Read,
+					resource:   "foo",
+					tenant:     "a",
+					output:     true,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Write,
+					resource:   "foo",
+					tenant:     "a",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Write,
+					resource:   "foo",
+					tenant:     "b",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Write,
+					resource:   "bar",
+					tenant:     "b",
+					output:     false,
+				},
+			},
+		},
+		{
+			name: "group erika read for a",
+			roles: []Role{
+				{
+					Name:        "a-read",
+					Resources:   []string{"foo"},
+					Tenants:     []string{"a"},
+					Permissions: []Permission{"read"},
+				},
+			},
+			roleBindings: []RoleBinding{
+				{
+					Name:     "erika-a",
+					Roles:    []string{"a-read"},
+					Subjects: []Subject{{Name: "erika", Kind: Group}},
+				},
+			},
+			ios: []io{
+				{
+					subject:    "erika",
+					groups:     []string{"erika", "mustermann"},
+					permission: Read,
+					resource:   "foo",
+					tenant:     "a",
+					output:     true,
+				},
+				{
+					subject:    "erika",
+					groups:     []string{"erika", "mustermann"},
+					permission: Write,
+					resource:   "foo",
+					tenant:     "a",
+					output:     false,
+				},
+				{
+					subject:    "erika",
+					groups:     []string{"erika", "mustermann"},
+					permission: Read,
+					resource:   "foo",
+					tenant:     "b",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Read,
+					resource:   "foo",
+					tenant:     "a",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Write,
+					resource:   "foo",
+					tenant:     "a",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Write,
+					resource:   "foo",
+					tenant:     "b",
+					output:     false,
+				},
+				{
+					subject:    "max",
+					groups:     []string{"mustermann", "other"},
+					permission: Write,
+					resource:   "bar",
+					tenant:     "b",
+					output:     false,
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAuthorzer(tc.roles, tc.roleBindings)
 			for i := range tc.ios {
-				if a.Authorize(tc.ios[i].subject, tc.ios[i].permission, tc.ios[i].resource, tc.ios[i].tenant) != tc.ios[i].output {
+				if a.Authorize(tc.ios[i].subject, tc.ios[i].groups, tc.ios[i].permission, tc.ios[i].resource, tc.ios[i].tenant) != tc.ios[i].output {
 					t.Errorf("test case %d: expected %t; got %t", i, tc.ios[i].output, !tc.ios[i].output)
 				}
 			}

--- a/test/config/rbac.yaml
+++ b/test/config/rbac.yaml
@@ -22,9 +22,11 @@ roleBindings:
   roles:
   - read-write-oidc
   subjects:
-  - admin@example.com
+  - name: admin@example.com
+    kind: user
 - name: test-mtls
   roles:
   - read-write-mtls
   subjects:
-  - up
+  - name: test
+    kind: group


### PR DESCRIPTION
This commit enables specifying groups in the RBAC file so that roles can
be bound to a set of users rather than just individually per user. Groups
are discovered in OIDC using the claim specified in each tenant's OIDC
configuration. In mTLS, groups are populated from the list of the client
certificate's organizational units.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers 