### PR TITLE
Update image tag for groups

### DIFF
--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -3,7 +3,7 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
     local cfg = self,
     name: 'observatorium-api',
     namespace: 'observatorium',
-    version: 'master-2020-06-22-v0.1.1-100-g571ce24',
+    version: 'master-2020-06-26-v0.1.1-105-gc784d77',
     image: 'quay.io/observatorium/observatorium:' + cfg.version,
     replicas: 3,
     metrics: {

--- a/examples/manifests/configmap-with-tls.yaml
+++ b/examples/manifests/configmap-with-tls.yaml
@@ -23,6 +23,6 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium

--- a/examples/manifests/configmap.yaml
+++ b/examples/manifests/configmap.yaml
@@ -23,6 +23,6 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/instance: observatorium-api
         app.kubernetes.io/name: observatorium-api
-        app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+        app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
         - --tls.server.key-file=/mnt/certs/server.key
         - --tls.healthchecks.server-ca-file=/mnt/certs/ca.pem
         - --tls.reload-interval=1m
-        image: quay.io/observatorium/observatorium:master-2020-06-22-v0.1.1-100-g571ce24
+        image: quay.io/observatorium/observatorium:master-2020-06-26-v0.1.1-105-gc784d77
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/instance: observatorium-api
         app.kubernetes.io/name: observatorium-api
-        app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+        app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
     spec:
       containers:
       - args:
@@ -39,7 +39,7 @@ spec:
         - --log.level=warn
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
-        image: quay.io/observatorium/observatorium:master-2020-06-22-v0.1.1-100-g571ce24
+        image: quay.io/observatorium/observatorium:master-2020-06-26-v0.1.1-105-gc784d77
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/examples/manifests/secret-with-tls.yaml
+++ b/examples/manifests/secret-with-tls.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium
 stringData:

--- a/examples/manifests/secret.yaml
+++ b/examples/manifests/secret.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium
 stringData:

--- a/examples/manifests/service-with-tls.yaml
+++ b/examples/manifests/service-with-tls.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium
 spec:

--- a/examples/manifests/service.yaml
+++ b/examples/manifests/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-22-v0.1.1-100-g571ce24
+    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
   name: observatorium-api
   namespace: observatorium
 spec:


### PR DESCRIPTION
This commit updates the image tag to a version that supports groups in
RBAC.

cc @observatorium/maintainers 