### PR TITLE
internal/authentication: fix ctx when oidc group

### DIFF
--- a/internal/authentication/oidc.go
+++ b/internal/authentication/oidc.go
@@ -150,7 +150,7 @@ func newProvider(config OIDCConfig) (http.Handler, Middleware, error) {
 				case []string:
 					groups = v
 				}
-				ctx = context.WithValue(r.Context(), groupsKey, groups)
+				ctx = context.WithValue(ctx, groupsKey, groups)
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
When setting a group in OIDC, we are accidentally overwriting the
context, erasing the subject. This commit fixes it.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>