### PR TITLE
internal/authentication: groups as interface slice

### DIFF
--- a/internal/authentication/oidc.go
+++ b/internal/authentication/oidc.go
@@ -149,6 +149,11 @@ func newProvider(config OIDCConfig) (http.Handler, Middleware, error) {
 					groups = append(groups, v)
 				case []string:
 					groups = v
+				case []interface{}:
+					groups = make([]string, 0, len(v))
+					for i := range v {
+						groups = append(groups, fmt.Sprintf("%v", v[i]))
+					}
 				}
 				ctx = context.WithValue(ctx, groupsKey, groups)
 			}


### PR DESCRIPTION
This commit enables the OIDC authenticator to decode groups when they
come in as a slice of empty interfaces, which is how they are go-oidc
decodes them when they come from Dex's GitHub connector.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/admin 