### PR TITLE
*: enable using IdP with custom CA

### DIFF
--- a/test/config/dex.yaml
+++ b/test/config/dex.yaml
@@ -1,4 +1,4 @@
-issuer: http://127.0.0.1:5556/dex
+issuer: https://127.0.0.1:5556/dex
 storage:
   type: sqlite3
   config:
@@ -6,7 +6,9 @@ storage:
 frontend:
   dir: ./test/dex
 web:
-  http: 0.0.0.0:5556
+  https: 0.0.0.0:5556
+  tlsCert: ./tmp/certs/server.pem
+  tlsKey: ./tmp/certs/server.key
 telemetry:
   http: 0.0.0.0:5558
 logger:

--- a/test/config/tenants.yaml
+++ b/test/config/tenants.yaml
@@ -4,7 +4,8 @@ tenants:
   oidc:
     clientID: test
     clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
-    issuerURL: http://127.0.0.1:5556/dex
+    issuerCAPath: ./tmp/certs/ca.pem
+    issuerURL: https://127.0.0.1:5556/dex
     redirectURL: http://localhost:8080/oidc/test/callback
     usernameClaim: email
 - name: test-mtls

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -18,7 +18,8 @@ sleep 2
 
 token=$(curl --request POST \
     --silent \
-    --url http://localhost:5556/dex/token \
+    --cacert ./tmp/certs/ca.pem \
+    --url https://localhost:5556/dex/token \
     --header 'content-type: application/x-www-form-urlencoded' \
     --data grant_type=password \
     --data username=admin@example.com \


### PR DESCRIPTION
Some OIDC IdPs serve their API over TLS with custom certificates, e.g.
the OpenShift OAuth server. This commit enables the Observatorium API to
use such IdPs as OIDC servers and adds tests to verify that this
workflow works.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers