### PR TITLE
internal/authentication: don't fail broken oidc

### DIFF
--- a/internal/authentication/http.go
+++ b/internal/authentication/http.go
@@ -83,7 +83,7 @@ func WithTenantMiddlewares(middlewareSets ...map[string]Middleware) Middleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tenant, ok := GetTenant(r.Context())
 			if !ok {
-				http.Error(w, "error finding tenant", http.StatusInternalServerError)
+				http.Error(w, "error finding tenant", http.StatusBadRequest)
 				return
 			}
 			m, ok := middlewares[tenant]

--- a/internal/authentication/mtls.go
+++ b/internal/authentication/mtls.go
@@ -14,7 +14,7 @@ type MTLSConfig struct {
 }
 
 // NewMTLS creates a set of Middlewares for all specified tenants.
-func NewMTLS(configs ...MTLSConfig) map[string]Middleware {
+func NewMTLS(configs []MTLSConfig) map[string]Middleware {
 	middlewares := map[string]Middleware{}
 
 	for _, c := range configs {


### PR DESCRIPTION
Currently, if a single tenant has a broken OIDC configuration, then
entire Observatorium API will fail to start. This commit ensures that
broken configs are treated as warnings, allowing the rest of the API to
continue running. Tenants with broken configs will not be able to
authenticate and will get `bad request` responses when accessing their
URLs, since for all intents and purposes, that tenant does not actually
exist.

This code has been tested by appending a bad OIDC configuration to the
test/config/tenants.yaml file and running the integration tests.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze 