### PR TITLE
jsonnet: make TLS settings work with K8s Secret

### DIFF
--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -67,12 +67,10 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
 local apiWithTLS = api {
   config+:: {
     tls+: {
-      secret: {
-        serverCertFile: '/mnt/certs/server.pem',
-        serverPrivateKeyFile: '/mnt/certs/server.key',
-        serverCAFile: '/mnt/certs/ca.pem',
-        reloadInterval: '1m',
-      },
+      ca: '<PEM-encoded CA>',
+      cert: '<PEM-encoded cert>',
+      key: '<PEM-encoded key>',
+      reloadInterval: '1m',
     },
   },
 };

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -40,9 +40,9 @@ spec:
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --web.healthchecks.url=https://127.0.0.1:8080
-        - --tls.server.cert-file=/mnt/certs/server.pem
-        - --tls.server.key-file=/mnt/certs/server.key
-        - --tls.healthchecks.server-ca-file=/mnt/certs/ca.pem
+        - --tls.server.cert-file=/mnt/tls/cert.pem
+        - --tls.server.key-file=/mnt/tls/key.pem
+        - --tls.healthchecks.server-ca-file=/mnt/tls/ca.pem
         - --tls.reload-interval=1m
         image: quay.io/observatorium/observatorium:master-2020-06-26-v0.1.1-105-gc784d77
         livenessProbe:
@@ -74,8 +74,8 @@ spec:
           name: tenants
           readOnly: true
           subPath: tenants.yaml
-        - mountPath: /mnt/certs
-          name: certs
+        - mountPath: /mnt/tls
+          name: tls
           readOnly: true
       volumes:
       - configMap:
@@ -84,6 +84,6 @@ spec:
       - name: tenants
         secret:
           secretName: observatorium-api
-      - name: certs
+      - name: tls
         secret:
-          secretName: observatorium-api-tls-certs
+          secretName: observatorium-api

--- a/examples/manifests/secret-with-tls.yaml
+++ b/examples/manifests/secret-with-tls.yaml
@@ -9,6 +9,9 @@ metadata:
   name: observatorium-api
   namespace: observatorium
 stringData:
+  ca.pem: <PEM-encoded CA>
+  cert.pem: <PEM-encoded cert>
+  key.pem: <PEM-encoded key>
   tenants.yaml: |-
     "tenants":
     - "id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"


### PR DESCRIPTION
Previously, the TLS settings required configuring Jsonnet code AND
manually creating and deploying a magically-named Secret containing
the TLS data. This commit refactors this code so that the Secret is
automatically generated and mounted from provided TLS data.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

The deployments PR (https://github.com/observatorium/deployments/pull/273) needs a big refactor in order to work and these changes will support and simplify that code.

cc @metalmatze 