### PR TITLE
allow setting server name in healthcheck TLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Usage of ./observatorium:
     	Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used. Note that TLS 1.3 ciphersuites are not configurable.
   -tls.healthchecks.server-ca-file string
     	File containing the TLS CA against which to verify servers. If no server CA is specified, the client will use the system certificates.
+  -tls.healthchecks.server-name string
+    	Server name is used to verify the hostname of the certificates returned by the server. If no server name is specified, the server name will be inferred from the healthcheck URL.
   -tls.min-version string
     	Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS13")
   -tls.reload-interval duration

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -94,8 +94,19 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             '--tls.server.cert-file=/mnt/tls/cert.pem',
             '--tls.server.key-file=/mnt/tls/key.pem',
             '--tls.healthchecks.server-ca-file=/mnt/tls/ca.pem',
-            '--tls.reload-interval=' + api.config.tls.reloadInterval,
-          ]
+          ] + (
+            if std.objectHas(api.config.tls, 'reloadInterval') then
+              [
+                '--tls.reload-interval=' + api.config.tls.reloadInterval,
+              ]
+            else []
+          ) + (
+            if std.objectHas(api.config.tls, 'serverName') then
+              [
+                '--tls.healthchecks.server-name=' + api.config.tls.serverName,
+              ]
+            else []
+          )
         else []
       )) +
       container.withPorts([


### PR DESCRIPTION
Currently, the TLS configuration used by the healthchecker HTTP client
always defaults to verifying the server name of the certificate using
the hostname of the healthcheck URL. This does not work in most
production configurations, where the certificate issued by a real CA,
e.g. Let's Encrypt, only includes the domain name in the subject. This
means that verifying the subject, e.g. example.com against the hostname,
i.e. `localhost`, will always fail.

This commit enables configuring the server name to use for certificate
verification.

cc @observatorium/maintainers @clyang82 