### PR TITLE
jsonnet: decouple deployment from secret

### DIFF
--- a/examples/main.jsonnet
+++ b/examples/main.jsonnet
@@ -3,7 +3,7 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
     local cfg = self,
     name: 'observatorium-api',
     namespace: 'observatorium',
-    version: 'master-2020-06-26-v0.1.1-105-gc784d77',
+    version: 'master-2020-09-04-v0.1.1-131-ga4c5a9c',
     image: 'quay.io/observatorium/observatorium:' + cfg.version,
     replicas: 3,
     metrics: {
@@ -67,10 +67,13 @@ local api = (import '../jsonnet/lib/observatorium-api.libsonnet') {
 local apiWithTLS = api {
   config+:: {
     tls+: {
-      ca: '<PEM-encoded CA>',
-      cert: '<PEM-encoded cert>',
-      key: '<PEM-encoded key>',
+      certKey: 'cert',
+      keyKey: 'key',
+      secretName: 'observatorium-api-tls',
+      configMapName: 'observatorium-api-tls',
+      caKey: 'ca',
       reloadInterval: '1m',
+      serverName: 'example.com',
     },
   },
 };

--- a/examples/manifests/configmap-with-tls.yaml
+++ b/examples/manifests/configmap-with-tls.yaml
@@ -23,6 +23,6 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium

--- a/examples/manifests/configmap.yaml
+++ b/examples/manifests/configmap.yaml
@@ -23,6 +23,6 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium

--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/instance: observatorium-api
         app.kubernetes.io/name: observatorium-api
-        app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+        app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
     spec:
       containers:
       - args:
@@ -40,11 +40,12 @@ spec:
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --web.healthchecks.url=https://127.0.0.1:8080
-        - --tls.server.cert-file=/mnt/tls/cert.pem
-        - --tls.server.key-file=/mnt/tls/key.pem
-        - --tls.healthchecks.server-ca-file=/mnt/tls/ca.pem
+        - --tls.server.cert-file=/var/run/tls/cert
+        - --tls.server.key-file=/var/run/tls/key
+        - --tls.healthchecks.server-ca-file=/var/run/tls/ca
         - --tls.reload-interval=1m
-        image: quay.io/observatorium/observatorium:master-2020-06-26-v0.1.1-105-gc784d77
+        - --tls.healthchecks.server-name=example.com
+        image: quay.io/observatorium/observatorium:master-2020-09-04-v0.1.1-131-ga4c5a9c
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -74,9 +75,18 @@ spec:
           name: tenants
           readOnly: true
           subPath: tenants.yaml
-        - mountPath: /mnt/tls
-          name: tls
+        - mountPath: /var/run/tls/cert
+          name: tls-secret
           readOnly: true
+          subPath: cert
+        - mountPath: /var/run/tls/key
+          name: tls-secret
+          readOnly: true
+          subPath: key
+        - mountPath: /var/run/tls/ca
+          name: tls-configmap
+          readOnly: true
+          subPath: ca
       volumes:
       - configMap:
           name: observatorium-api
@@ -84,6 +94,9 @@ spec:
       - name: tenants
         secret:
           secretName: observatorium-api
-      - name: tls
+      - name: tls-secret
         secret:
-          secretName: observatorium-api
+          secretName: observatorium-api-tls
+      - configMap:
+          name: observatorium-api-tls
+        name: tls-configmap

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/instance: observatorium-api
         app.kubernetes.io/name: observatorium-api
-        app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+        app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
     spec:
       containers:
       - args:
@@ -39,7 +39,7 @@ spec:
         - --logs.write.endpoint=http://127.0.0.1:3100
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
-        image: quay.io/observatorium/observatorium:master-2020-06-26-v0.1.1-105-gc784d77
+        image: quay.io/observatorium/observatorium:master-2020-09-04-v0.1.1-131-ga4c5a9c
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/examples/manifests/secret-with-tls.yaml
+++ b/examples/manifests/secret-with-tls.yaml
@@ -5,13 +5,10 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium
 stringData:
-  ca.pem: <PEM-encoded CA>
-  cert.pem: <PEM-encoded cert>
-  key.pem: <PEM-encoded key>
   tenants.yaml: |-
     "tenants":
     - "id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"

--- a/examples/manifests/secret.yaml
+++ b/examples/manifests/secret.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium
 stringData:

--- a/examples/manifests/service-with-tls.yaml
+++ b/examples/manifests/service-with-tls.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium
 spec:

--- a/examples/manifests/service.yaml
+++ b/examples/manifests/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api
     app.kubernetes.io/name: observatorium-api
-    app.kubernetes.io/version: master-2020-06-26-v0.1.1-105-gc784d77
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
   name: observatorium-api
   namespace: observatorium
 spec:


### PR DESCRIPTION
PR #87 was intended to decouple the deployment from a secret with a
magic, hard-coded name, but it obligated all consumers of this library
to render a secret and configmap using this jsonnet, rather than truly
decouple the deployment from the configuration files. This meant that
e.g. a custom resource for the Observatorium operator would need to have
the certificates in-line in order to render this manifest, which caused
two issues:
1. it put secrets in otherwise plain-text files; and
2. it prevented (re-)using secrets that may be created by another
service, e.g. cert-manager.

This PR fixes this by truly decoupling the deployment and the
configuration files. Now, the jsonnet accepts a secret name and keys to
specify where the API can find the certificates it needs.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @clyang82 @observatorium/maintainers @marcolan018