### PR TITLE
internal/authentication: panic when no middleware

### DIFF
--- a/internal/authentication/oidc.go
+++ b/internal/authentication/oidc.go
@@ -46,6 +46,7 @@ func NewOIDC(configs []OIDCConfig) (http.Handler, map[string]Middleware, []error
 		h, m, err := newProvider(c)
 		if err != nil {
 			warnings = append(warnings, fmt.Errorf("failed to instantiate OIDC provider for tenant %q: %w", c.Tenant, err))
+			continue
 		}
 
 		handlers[c.Tenant] = h


### PR DESCRIPTION
Currently, the Observatorium API can start up if a tenant's OIDC
configuration is broken. However, this introduces a nil middleware into
the middlewares map, which causes the handler to panic when a request is
received. This commit fixes this by skipping nil middlewares during
generation.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers 