### PR TITLE
jsonnet: enable TLS without ConfigMap

### DIFF
--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -162,7 +162,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
          ] + (
            if std.objectHas(api.config.tls, 'caKey') then [
              {
-               name: 'tls-configmap',
+               name: 'tls-%s' % (if std.objectHas(api.config.tls, 'configMapName') then 'configmap' else 'secret'),
                mountPath: '/var/run/tls/' + api.config.tls.caKey,
                subPath: api.config.tls.caKey,
                readOnly: true,
@@ -202,7 +202,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
            name: 'tls-secret',
          },
        ] + (
-         if std.objectHas(api.config.tls, 'caKey') then [
+         if std.objectHas(api.config.tls, 'configMapName') then [
            {
              configMap: {
                name: api.config.tls.configMapName,


### PR DESCRIPTION
Some certificate providers do not put the CA used to sign a
certificate in a ConfigMap but rather in the same Secret as the
certificate itself, e.g. cert-manager. This commit enables configuring
the CA for the Observatorium API using the same Secret that contains
the certificate and thus enables operation with cert-manager.

The logic is as follows if a caKey is given:
1. if no configMapName is provided, then mount the CA from the same
Secret as the certificate and key; else
2. if a configMapName is provided, then mount the CA from the ConfigMap.

In other words, when no configMapName is specified, the Jsonnet will
default to mounting the CA from the Secret.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers @clyang82 