### PR TITLE
Create sa instead of use default

### DIFF
--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -87,6 +87,7 @@ spec:
           name: tls-configmap
           readOnly: true
           subPath: ca
+      serviceAccount: observatorium-api
       volumes:
       - configMap:
           name: observatorium-api

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -69,6 +69,7 @@ spec:
           name: tenants
           readOnly: true
           subPath: tenants.yaml
+      serviceAccount: observatorium-api
       volumes:
       - configMap:
           name: observatorium-api

--- a/examples/manifests/serviceAccount-with-tls.yaml
+++ b/examples/manifests/serviceAccount-with-tls.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium-api
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
+  name: observatorium-api
+  namespace: observatorium

--- a/examples/manifests/serviceAccount.yaml
+++ b/examples/manifests/serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium-api
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/version: master-2020-09-04-v0.1.1-131-ga4c5a9c
+  name: observatorium-api
+  namespace: observatorium

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -39,6 +39,14 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
   },
 
+  serviceAccount:
+    local sa = k.core.v1.serviceAccount;
+
+    sa.new() +
+    sa.mixin.metadata.withName(api.config.name) +
+    sa.mixin.metadata.withNamespace(api.config.namespace) +
+    sa.mixin.metadata.withLabels(api.config.commonLabels),
+
   service:
     local service = k.core.v1.service;
     local ports = service.mixin.spec.portsType;
@@ -186,6 +194,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     deployment.mixin.metadata.withNamespace(api.config.namespace) +
     deployment.mixin.metadata.withLabels(api.config.commonLabels) +
     deployment.mixin.spec.selector.withMatchLabels(api.config.podLabelSelector) +
+    deployment.mixin.spec.template.spec.withServiceAccount(api.serviceAccount.metadata.name) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.spec.withVolumes(


### PR DESCRIPTION
Pod analysis shows most observability pods use the default service account with cluster-admin access. A separate service account should be used by the pods so they can each be bound to only the privileges they need. None of them should be using the default service account or the wild card privileges `[map[apiGroups:[*] resources:[*] verbs:[*]] map[nonResourceURLs:[*] verbs:[*]]]` that the default service account currently uses.