### PR TITLE
Add throttle limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Usage of ./observatorium:
     	The name of the HTTP header containing the tenant ID to forward to the metrics upstreams. (default "THANOS-TENANT")
   -metrics.write.endpoint string
     	The endpoint against which to make write requests for metrics.
+  -middleware.concurrent-request-limit int
+    	The limit that controls number of currently processed requests at a time across all tenants. (default 10000)
   -middleware.rate-limiter.grpc-address string
     	The gRPC Server Address against which to run rate limit checks when the rate limits are specified for a given tenant. If not specified, local, non-shared rate limiting will be used.
   -rbac.config string

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Usage of ./observatorium:
   -metrics.write.endpoint string
     	The endpoint against which to make write requests for metrics.
   -middleware.concurrent-request-limit int
-    	The limit that controls number of currently processed requests at a time across all tenants. (default 10000)
+    	The limit that controls the number of concurrently processed requests across all tenants. (default 10000)
   -middleware.rate-limiter.grpc-address string
     	The gRPC Server Address against which to run rate limit checks when the rate limits are specified for a given tenant. If not specified, local, non-shared rate limiting will be used.
   -rbac.config string

--- a/main.go
+++ b/main.go
@@ -669,7 +669,7 @@ func parseFlags() (config, error) {
 		"The gRPC Server Address against which to run rate limit checks when the rate limits are specified for a given tenant."+
 			" If not specified, local, non-shared rate limiting will be used.")
 	flag.IntVar(&cfg.middleware.concurrentRequestLimit, "middleware.concurrent-request-limit", 10_000,
-		"The limit that controls number of currently processed requests at a time across all tenants.")
+		"The limit that controls the number of concurrently processed requests across all tenants.")
 	flag.Parse()
 
 	metricsReadEndpoint, err := url.ParseRequestURI(rawMetricsReadEndpoint)

--- a/main.go
+++ b/main.go
@@ -61,15 +61,15 @@ type config struct {
 	logLevel  string
 	logFormat string
 
-	rbacConfigPath     string
-	tenantsConfigPath  string
-	rateLimiterAddress string
+	rbacConfigPath    string
+	tenantsConfigPath string
 
-	debug   debugConfig
-	server  serverConfig
-	tls     tlsConfig
-	metrics metricsConfig
-	logs    logsConfig
+	debug      debugConfig
+	server     serverConfig
+	tls        tlsConfig
+	metrics    metricsConfig
+	logs       logsConfig
+	middleware middlewareConfig
 }
 
 type debugConfig struct {
@@ -109,6 +109,11 @@ type logsConfig struct {
 	tenantHeader  string
 	// enable logs at least one {read,write,tail}Endpoint} is provided.
 	enabled bool
+}
+
+type middlewareConfig struct {
+	rateLimiterAddress     string
+	concurrentRequestLimit int
 }
 
 //nolint:funlen,gocyclo,gocognit
@@ -280,12 +285,12 @@ func main() {
 
 	var rateLimitClient *ratelimit.Client
 
-	if cfg.rateLimiterAddress != "" {
+	if cfg.middleware.rateLimiterAddress != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), grpcDialTimeout)
 		defer cancel()
 
 		rateLimitClient = ratelimit.NewClient(reg)
-		if err := rateLimitClient.Dial(ctx, cfg.rateLimiterAddress); err != nil {
+		if err := rateLimitClient.Dial(ctx, cfg.middleware.rateLimiterAddress); err != nil {
 			stdlog.Fatal(err)
 		}
 	}
@@ -339,6 +344,7 @@ func main() {
 		r.Use(middleware.Recoverer)
 		r.Use(middleware.StripSlashes)
 		r.Use(middleware.Timeout(middlewareTimeout)) // best set per handler.
+		r.Use(middleware.Throttle(cfg.middleware.concurrentRequestLimit))
 		r.Use(server.Logger(logger))
 
 		ins := signalhttp.NewHandlerInstrumenter(reg, []string{"group", "handler"})
@@ -659,9 +665,11 @@ func parseFlags() (config, error) {
 			" Note that TLS 1.3 ciphersuites are not configurable.")
 	flag.DurationVar(&cfg.tls.reloadInterval, "tls.reload-interval", time.Minute,
 		"The interval at which to watch for TLS certificate changes.")
-	flag.StringVar(&cfg.rateLimiterAddress, "middleware.rate-limiter.grpc-address", "",
+	flag.StringVar(&cfg.middleware.rateLimiterAddress, "middleware.rate-limiter.grpc-address", "",
 		"The gRPC Server Address against which to run rate limit checks when the rate limits are specified for a given tenant."+
 			" If not specified, local, non-shared rate limiting will be used.")
+	flag.IntVar(&cfg.middleware.concurrentRequestLimit, "middleware.concurrent-request-limit", 10_000,
+		"The limit that controls number of currently processed requests at a time across all tenants.")
 	flag.Parse()
 
 	metricsReadEndpoint, err := url.ParseRequestURI(rawMetricsReadEndpoint)


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

This PR adds global throttling that controls number of currently processed requests at a time across all tenants. 
In addition to [rate-limiting per tenant](https://github.com/observatorium/observatorium/pull/102).