### PR TITLE
Add serviceCA to jsonnet lib

### DIFF
--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -212,7 +212,15 @@
                        readOnly: true,
                      },
                    ] else []
-                 ) else []),
+                 ) else [])+
+                (if std.objectHas(api.config, 'serviceCA') then [
+                    {
+                      name: 'service-ca',
+                      mountPath: '/var/run/tls/service-ca.crt',
+                      subPath: 'service-ca.crt',
+                      readOnly: true,
+                    }
+                 ] else []),
             },
           ],
           volumes:
@@ -263,7 +271,16 @@
                    name: 'tls-configmap',
                  },
                ] else []
-             ) else []),
+             ) else []) +
+            (if std.objectHas(api.config, 'serviceCA') then [
+              {
+                configMap: {
+                  name: api.config.serviceCA,
+                },
+                name: 'service-ca',
+              },
+              ] else []
+            ),
         },
       },
     },


### PR DESCRIPTION
Includes a new configuration property for the API, allowing consumers to specify the name of the config map containing the service-ca.crt, typically created via OpenShift's certificate service.

The first iteration of this PR is mainly my naive suggestion to solve the problem that I'm facing with observatorium/deployments#347.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
