### PR TITLE
add log api to support Loki datasources in Grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# IDEs
+.idea
+
 observatorium
 tmp/
 examples/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# IDEs
-.idea
-
 observatorium
 tmp/
 examples/vendor

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -167,8 +167,8 @@ if $UP \
   --tls-ca-file=./tmp/certs/ca.pem \
   --tls-client-cert-file=./tmp/certs/client.pem \
   --tls-client-private-key-file=./tmp/certs/client.key \
-  --endpoint-read=https://127.0.0.1:8443/api/logs/v1/test-mtls/api/v1/query \
-  --endpoint-write=https://127.0.0.1:8443/api/logs/v1/test-mtls/api/v1/push \
+  --endpoint-read=https://127.0.0.1:8443/api/logs/v1/test-mtls/loki/api/v1/query \
+  --endpoint-write=https://127.0.0.1:8443/api/logs/v1/test-mtls/loki/api/v1/push \
   --period=500ms \
   --initial-query-delay=250ms \
   --threshold=1 \


### PR DESCRIPTION
Add APIs to support the Loki datasource in Grafana 7 and earlier (https://grafana.com/docs/loki/latest/api/#microservices-mode).

Verified with Grafana 6 and 7.