### PR TITLE
Add dex parameter to make run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build: observatorium
 
 .PHONY: run
 run: build $(THANOS) $(DEX) $(LOKI) generate-cert
-	PATH=$$PATH:$(BIN_DIR):$(FIRST_GOPATH)/bin ./test/run-local.sh
+	PATH=$$PATH:$(BIN_DIR):$(FIRST_GOPATH)/bin DEX=$(DEX) ./test/run-local.sh
 
 .PHONY: deps
 deps: go.mod go.sum


### PR DESCRIPTION
make run was failing to find `dex`. This fixes the problem by providing the bingo path to `dex`

```
$ make run
go mod tidy
go mod download
go mod verify
all modules verified
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on GOPROXY=https://proxy.golang.org go build -a -ldflags '-s -w' -o observatorium .
PATH=$PATH:/home/brett/projects/redhat/observatorium/tmp/bin:/home/brett/.go/bin ./test/run-local.sh
-------------------------------------------
- Waiting for Dex to come up...  -
-------------------------------------------
./test/run-local.sh: line 16: dex: command not found
..................................^C./test/run-local.sh: line 1: kill: (1207933) - No such process
make: *** [Makefile:77: run] Interrupt
```