### PR TITLE
Add a flag for choosing trace endpoint type

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Usage of ./observatorium:
   -debug.name string
     	A name to add as a prefix to log lines. (default "observatorium")
   -internal.tracing.endpoint string
-    	The full URL of the trace collector. If it's not set, tracing will be disabled.
+    	The full URL of the trace agent or collector. If it's not set, tracing will be disabled.
+  -internal.tracing.endpoint-type string
+    	The tracing endpoint type. Options: 'agent', 'collector'. (default "agent")
   -internal.tracing.sampling-fraction float
     	The fraction of traces to sample. Thus, if you set this to .5, half of traces will be sampled. (default 0.1)
   -internal.tracing.service-name string

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -160,6 +160,12 @@ function(params) {
                       ]
                     else []
                   ) + (
+                    if std.objectHas(api.config.internal.tracing, 'endpointType') then
+                      [
+                        '--internal.tracing.endpoint-type=' + api.config.internal.tracing.endpointType,
+                      ]
+                    else []
+                  ) + (
                     if std.objectHas(api.config.internal.tracing, 'samplingFraction') then
                       [
                         '--internal.tracing.sampling-fraction=' + api.config.internal.tracing.samplingFraction,

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ type middlewareConfig struct {
 type internalTracingConfig struct {
 	serviceName      string
 	endpoint         string
-	endpointType     string
+	endpointType     tracing.EndpointType
 	samplingFraction float64
 }
 
@@ -636,6 +636,7 @@ func parseFlags() (config, error) {
 		rawLogsReadEndpoint     string
 		rawLogsTailEndpoint     string
 		rawLogsWriteEndpoint    string
+		rawTracingEndpointType  string
 	)
 
 	cfg := config{}
@@ -658,7 +659,7 @@ func parseFlags() (config, error) {
 		"The service name to report to the tracing backend.")
 	flag.StringVar(&cfg.internalTracing.endpoint, "internal.tracing.endpoint", "",
 		"The full URL of the trace agent or collector. If it's not set, tracing will be disabled.")
-	flag.StringVar(&cfg.internalTracing.endpointType, "internal.tracing.endpoint-type", tracing.EndpointTypeAgent,
+	flag.StringVar(&rawTracingEndpointType, "internal.tracing.endpoint-type", string(tracing.EndpointTypeAgent),
 		fmt.Sprintf("The tracing endpoint type. Options: '%s', '%s'.", tracing.EndpointTypeAgent, tracing.EndpointTypeCollector))
 	flag.Float64Var(&cfg.internalTracing.samplingFraction, "internal.tracing.sampling-fraction", 0.1,
 		"The fraction of traces to sample. Thus, if you set this to .5, half of traces will be sampled.")
@@ -758,6 +759,8 @@ func parseFlags() (config, error) {
 	if rawTLSCipherSuites != "" {
 		cfg.tls.cipherSuites = strings.Split(rawTLSCipherSuites, ",")
 	}
+
+	cfg.internalTracing.endpointType = tracing.EndpointType(rawTracingEndpointType)
 
 	return cfg, nil
 }

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ type middlewareConfig struct {
 type internalTracingConfig struct {
 	serviceName      string
 	endpoint         string
+	endpointType     string
 	samplingFraction float64
 }
 
@@ -136,7 +137,12 @@ func main() {
 	logger := logger.NewLogger(cfg.logLevel, cfg.logFormat, cfg.debug.name)
 	defer level.Info(logger).Log("msg", "exiting")
 
-	tp, closer, err := tracing.InitTracer(cfg.internalTracing.serviceName, cfg.internalTracing.endpoint, cfg.internalTracing.samplingFraction)
+	tp, closer, err := tracing.InitTracer(
+		cfg.internalTracing.serviceName,
+		cfg.internalTracing.endpoint,
+		cfg.internalTracing.endpointType,
+		cfg.internalTracing.samplingFraction,
+	)
 	if err != nil {
 		stdlog.Fatalf("initialize tracer: %v", err)
 	}
@@ -651,7 +657,9 @@ func parseFlags() (config, error) {
 	flag.StringVar(&cfg.internalTracing.serviceName, "internal.tracing.service-name", "observatorium_api",
 		"The service name to report to the tracing backend.")
 	flag.StringVar(&cfg.internalTracing.endpoint, "internal.tracing.endpoint", "",
-		"The full URL of the trace collector. If it's not set, tracing will be disabled.")
+		"The full URL of the trace agent or collector. If it's not set, tracing will be disabled.")
+	flag.StringVar(&cfg.internalTracing.endpointType, "internal.tracing.endpoint-type", tracing.EndpointTypeAgent,
+		"The tracing endpoint type. Options: 'agent', 'collector'.")
 	flag.Float64Var(&cfg.internalTracing.samplingFraction, "internal.tracing.sampling-fraction", 0.1,
 		"The fraction of traces to sample. Thus, if you set this to .5, half of traces will be sampled.")
 	flag.StringVar(&cfg.server.listen, "web.listen", ":8080",

--- a/main.go
+++ b/main.go
@@ -659,7 +659,7 @@ func parseFlags() (config, error) {
 	flag.StringVar(&cfg.internalTracing.endpoint, "internal.tracing.endpoint", "",
 		"The full URL of the trace agent or collector. If it's not set, tracing will be disabled.")
 	flag.StringVar(&cfg.internalTracing.endpointType, "internal.tracing.endpoint-type", tracing.EndpointTypeAgent,
-		"The tracing endpoint type. Options: 'agent', 'collector'.")
+		fmt.Sprintf("The tracing endpoint type. Options: '%s', '%s'.", tracing.EndpointTypeAgent, tracing.EndpointTypeCollector))
 	flag.Float64Var(&cfg.internalTracing.samplingFraction, "internal.tracing.sampling-fraction", 0.1,
 		"The fraction of traces to sample. Thus, if you set this to .5, half of traces will be sampled.")
 	flag.StringVar(&cfg.server.listen, "web.listen", ":8080",

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// EndpointType represents the type of the tracing endpoint.
 const (
 	EndpointTypeCollector = "collector"
 	EndpointTypeAgent     = "agent"

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -16,7 +16,7 @@ const (
 	EndpointTypeAgent     = "agent"
 )
 
-// InitTracer creates an OTel TracerProvider that exports the traces to a Jaeger collector.
+// InitTracer creates an OTel TracerProvider that exports the traces to a Jaeger agent/collector.
 func InitTracer(
 	serviceName string,
 	endpoint string,

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -12,16 +12,18 @@ import (
 )
 
 // EndpointType represents the type of the tracing endpoint.
+type EndpointType string
+
 const (
-	EndpointTypeCollector = "collector"
-	EndpointTypeAgent     = "agent"
+	EndpointTypeCollector EndpointType = "collector"
+	EndpointTypeAgent     EndpointType = "agent"
 )
 
 // InitTracer creates an OTel TracerProvider that exports the traces to a Jaeger agent/collector.
 func InitTracer(
 	serviceName string,
 	endpoint string,
-	endpointType string,
+	endpointType EndpointType,
 	samplingFraction float64,
 ) (tp trace.TracerProvider, closer func(), err error) {
 	endpointOption := jaeger.WithAgentEndpoint(endpoint)


### PR DESCRIPTION
Add a flag to specify if the trace endpoint is an agent or a collector.