### PR TITLE
Return non-200 HTTP response code if concurrent API requests cross the specified concurrent-request-limit #

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Usage of ./observatorium:
     	The name of the HTTP header containing the tenant ID to forward to the metrics upstreams. (default "THANOS-TENANT")
   -metrics.write.endpoint string
     	The endpoint against which to make write requests for metrics.
+  -middleware.backlog-duration-concurrent-requests int
+    	The time in millseconds to buffer up concurrent requests. (default 1)
+  -middleware.backlog-limit-concurrent-requests int
+    	The number of concurrent requests that can buffered.
   -middleware.concurrent-request-limit int
     	The limit that controls the number of concurrently processed requests across all tenants. (default 10000)
   -middleware.rate-limiter.grpc-address string

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Usage of ./observatorium:
     	The name of the HTTP header containing the tenant ID to forward to the metrics upstreams. (default "THANOS-TENANT")
   -metrics.write.endpoint string
     	The endpoint against which to make write requests for metrics.
-  -middleware.backlog-duration-concurrent-requests int
-    	The time in millseconds to buffer up concurrent requests. (default 1)
+  -middleware.backlog-duration-concurrent-requests duration
+    	The time duration to buffer up concurrent requests. (default 1ms)
   -middleware.backlog-limit-concurrent-requests int
     	The number of concurrent requests that can buffered.
   -middleware.concurrent-request-limit int

--- a/main.go
+++ b/main.go
@@ -369,7 +369,9 @@ func main() {
 		r.Use(middleware.Recoverer)
 		r.Use(middleware.StripSlashes)
 		r.Use(middleware.Timeout(middlewareTimeout)) // best set per handler.
-		r.Use(middleware.Throttle(cfg.middleware.concurrentRequestLimit))
+		// With zero backlog and backlog getting timing out immediately with 1ms, all concurrent requests beyond cfg.middleware.concurrentRequestLimit result in immediate non-200 HTTP response.
+		backlogDuration, _ := time.ParseDuration("1ms")
+		r.Use(middleware.ThrottleBacklog(cfg.middleware.concurrentRequestLimit, 0, backlogDuration))
 		r.Use(server.Logger(logger))
 
 		ins := signalhttp.NewHandlerInstrumenter(reg, []string{"group", "handler"})

--- a/main.go
+++ b/main.go
@@ -369,8 +369,8 @@ func main() {
 		r.Use(middleware.Recoverer)
 		r.Use(middleware.StripSlashes)
 		r.Use(middleware.Timeout(middlewareTimeout)) // best set per handler.
-		// With zero backlog and backlog getting timing out immediately with 1ms, all concurrent requests beyond cfg.middleware.concurrentRequestLimit result in immediate non-200 HTTP response.
-		backlogDuration, _ := time.ParseDuration("1ms")
+		// With zero backlog concurrent requests crossing a rate-limit result in non-200 HTTP response.
+		backlogDuration := 1 * time.Millisecond
 		r.Use(middleware.ThrottleBacklog(cfg.middleware.concurrentRequestLimit, 0, backlogDuration))
 		r.Use(server.Logger(logger))
 


### PR DESCRIPTION
With Zero backlog and backlog getting timing out immediately with 1ms, all concurrent requests beyond 'middleware.concurrent-request-limit' result in immediate non-200 HTTP response