### PR TITLE
website: fix 404 links to architecture

### DIFF
--- a/website/config/_default/menus.toml
+++ b/website/config/_default/menus.toml
@@ -1,10 +1,4 @@
 [[docs]]
-  name = "Architecture"
-  weight = 10
-  identifier = "architecture"
-  url = "/docs/architecture/"
-
-[[docs]]
   name = "Design"
   weight = 60
   identifier = "design"
@@ -12,7 +6,7 @@
 
 [[main]]
   name = "Docs"
-  url = "/docs/architecture/architecture.md/"
+  url = "/docs/usage/getting-started.md/"
   weight = 10
 
 # [[main]]

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -7,7 +7,7 @@
     </div>
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
-      <a class="btn btn-primary btn-lg px-4 mb-2" href="{{ "docs/architecture/architecture.md/" | relURL }}" role="button">Get started</a>
+      <a class="btn btn-primary btn-lg px-4 mb-2" href="{{ "docs/usage/getting-started.md/" | relURL }}" role="button">Get started</a>
       <p class="meta">Open-source Apache 2.0 Licensed. <a href="https://github.com/observatorium/observatorium">GitHub</a></p>
     </div>
   </div>


### PR DESCRIPTION
This commit fixes links in the website that are pointing to the
non-existant architecture/architecture path. It also removes this
section, which is currently empty, from the sidebar. Finally, it changes
the default docs and getting-started links to the getting-started.md
page.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>