### PR TITLE
components: Decouple thanos & loki secrets from minio

### DIFF
--- a/configuration/examples/dev/manifests/minio-deployment.yaml
+++ b/configuration/examples/dev/manifests/minio-deployment.yaml
@@ -19,8 +19,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          mkdir -p /storage/thanos && \
-          mkdir -p /storage/loki && \
+          mkdir -p /storage/thanos /storage/loki && \
           /usr/bin/minio server /storage
         env:
         - name: MINIO_ACCESS_KEY

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -6,6 +6,13 @@ local tenant = {
   user: 'user',
 };
 
+local minio = (import '../../components/minio.libsonnet')({
+  namespace: 'observatorium-minio',
+  buckets: ['thanos', 'loki'],
+  accessKey: 'minio',
+  secretKey: 'minio123',
+});
+
 local api = (import 'observatorium-api/observatorium-api.libsonnet');
 local obs = (import '../../components/observatorium.libsonnet');
 local dev = obs {
@@ -71,16 +78,41 @@ local dev = obs {
   ),
 };
 
-local minio = (import '../../components/minio.libsonnet')({
-  namespace: 'observatorium-minio',
-  bucketSecretNamespace: dev.config.namespace,
-});
-
 dev.manifests
 {
   'minio-deployment': minio.deployment,
   'minio-pvc': minio.pvc,
-  'minio-secret-thanos': minio.secretThanos,
-  'minio-secret-loki': minio.secretLoki,
+  'minio-secret-thanos': {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: 'thanos-objectstorage',
+      namespace: dev.config.namespace,
+    },
+    stringData: {
+      'thanos.yaml': |||
+        type: s3
+        config:
+          bucket: thanos
+          endpoint: %s.%s.svc.cluster.local:9000
+          insecure: true
+          access_key: minio
+          secret_key: minio123
+      ||| % [minio.service.metadata.name, minio.config.namespace],
+    },
+    type: 'Opaque',
+  },
+  'minio-secret-loki': {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: 'loki-objectstorage',
+      namespace: dev.config.namespace,
+    },
+    stringData: {
+      endpoint: 'http://minio:minio123@%s.%s.svc.cluster.local.:9000/loki' % [minio.service.metadata.name, minio.config.namespace],
+    },
+    type: 'Opaque',
+  },
   'minio-service': minio.service,
 }

--- a/configuration/examples/local/manifests/minio-deployment.yaml
+++ b/configuration/examples/local/manifests/minio-deployment.yaml
@@ -19,8 +19,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          mkdir -p /storage/thanos && \
-          mkdir -p /storage/loki && \
+          mkdir -p /storage/thanos /storage/loki && \
           /usr/bin/minio server /storage
         env:
         - name: MINIO_ACCESS_KEY


### PR DESCRIPTION
I'd like to reuse the minio component for something unrelated to thanos and loki. Regardless I think it didn't make sense for the secrets that are specific to thanos and loki to leak into the minio component. A next step might be to pass the secrets into the thanos/loki components, however, I didn't want to do that as I think that might be too opinionated, as many people prefer configuring secrets via vault or some other custom volume that is not necessarily a Kubernetes secret, so I didn't want to force one opinion or the other even stronger than we already are.

@kakkoyun @metalmatze @onprem @periklis 