### PR TITLE
configuration: rename obs/api default branch

### DIFF
--- a/configuration/jsonnetfile.json
+++ b/configuration/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "master",
+      "version": "main",
       "name": "observatorium-api"
     },
     {

--- a/configuration/jsonnetfile.lock.json
+++ b/configuration/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "0164651421f2d1b77db703bbeea501cb5b7a10cc",
+      "version": "d7b6867af17766826540ef9f7b06c84210d0481d",
       "sum": "Z86CgnoTybhpdQKWc2ptURmps1d9Qxhec0/IK6v71kY=",
       "name": "observatorium-api"
     },


### PR DESCRIPTION
This commit bumps the jb dependency files to use the new default branch
name for the observatorium/api repository.

xref: https://github.com/observatorium/api/pull/147

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

