### PR TITLE
Minio: Fix local/dev deployments, fix libsonnet

### DIFF
--- a/configuration/components/minio.libsonnet
+++ b/configuration/components/minio.libsonnet
@@ -42,20 +42,20 @@ function(params) {
                 '-c',
                 |||
                   mkdir -p %s && \
-                  /usr/bin/minio server /storage
+                  /usr/bin/docker-entrypoint.sh minio server /storage
                 ||| % std.join(' ', ['/storage/%s' % bucket for bucket in minio.config.buckets]),
               ],
               env: [
                 {
-                  name: 'MINIO_ACCESS_KEY',
+                  name: 'MINIO_ROOT_USER',
                   value: minio.config.accessKey,
                 },
                 {
-                  name: 'MINIO_SECRET_KEY',
+                  name: 'MINIO_ROOT_PASSWORD',
                   value: minio.config.secretKey,
                 },
               ],
-              image: 'minio/minio',
+              image: 'minio/minio:RELEASE.2021-09-09T21-37-07Z',
               name: 'minio',
               ports: [
                 { containerPort: 9000 },

--- a/configuration/examples/dev/manifests/minio-deployment.yaml
+++ b/configuration/examples/dev/manifests/minio-deployment.yaml
@@ -20,13 +20,13 @@ spec:
         - -c
         - |
           mkdir -p /storage/thanos /storage/loki && \
-          /usr/bin/minio server /storage
+          /usr/bin/docker-entrypoint.sh minio server /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: minio
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: minio123
-        image: minio/minio
+        image: minio/minio:RELEASE.2021-09-09T21-37-07Z
         name: minio
         ports:
         - containerPort: 9000

--- a/configuration/examples/local/manifests/minio-deployment.yaml
+++ b/configuration/examples/local/manifests/minio-deployment.yaml
@@ -20,13 +20,13 @@ spec:
         - -c
         - |
           mkdir -p /storage/thanos /storage/loki && \
-          /usr/bin/minio server /storage
+          /usr/bin/docker-entrypoint.sh minio server /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: minio
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: minio123
-        image: minio/minio
+        image: minio/minio:RELEASE.2021-09-09T21-37-07Z
         name: minio
         ports:
         - containerPort: 9000


### PR DESCRIPTION
While trying to spin up Observatorium in a local k8s cluster, I got this error after trying to deploy `minio`:

```bash
jessica@pop-os:~/workspace/observatorium/configuration/examples/local|main ⇒  kubectl get pods
NAME                     READY   STATUS             RESTARTS   AGE
minio-77f7856ddc-95zfm   0/1     CrashLoopBackOff   10         31m
jessica@pop-os:~/workspace/observatorium/configuration/examples/local|main ⇒  kubectl logs minio-77f7856ddc-95zfm
/bin/sh: line 1: /usr/bin/minio: No such file or directory
```

After some investigation with @ianbillett and following https://gitmemory.cn/repo/minio/minio/issues/13181, we've updated the command accordingly and also pinned the image to latest [release](https://github.com/minio/minio/releases/tag/RELEASE.2021-09-09T21-37-07Z).

We've also updated the env variables accordingly (so we don't get the message `WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated. Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD` anymore)

Not sure if this needs to be updated somewhere else too. Thanks!