### PR TITLE
Fix web targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,9 @@ web-pre: $(MDOX)
 	cd $(WEBSITE_DIR)/themes/doks/ && npm install && rm -rf content
 
 .PHONY: web
-web: web-pre
-web: $(WEBSITE_DIR)/node_modules $(HUGO)
+web: | web-pre $(WEBSITE_DIR)/node_modules $(HUGO)
 	cd $(WEBSITE_DIR) && $(HUGO) -b $(WEBSITE_BASE_URL)
 
 .PHONY: web-serve
-web-serve: web-pre
-web-serve: $(WEBSITE_DIR)/node_modules $(HUGO)
+web-serve: | web-pre $(WEBSITE_DIR)/node_modules $(HUGO)
 	@cd $(WEBSITE_DIR) && $(HUGO) serve


### PR DESCRIPTION
This PR fixes broken `web` & `web-serve` targets in Makefile as mentioned in #430 & #428.