### PR TITLE
Updating the local getting-started.md docs for MacOS compatibility

### DIFF
--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -99,7 +99,7 @@ We will be running `hydra` outside the cluster to simulate an external tenant, b
 
 **Linux**
 
-As our K8s cluster is running inside Docker containers, we can use the ip address of `docker0` interface to access host from inside the containers. In most cases it will be `172.17.0.1` but you can find yours using:
+As our K8s cluster is running inside Docker containers, we can use the IP address of the `docker0` interface to access the host from inside the containers. In most cases this IP address will be `172.17.0.1` but you can find yours using:
 ```bash
 ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1
 ```
@@ -110,7 +110,7 @@ If you are using Kind with Docker Desktop on Mac, there is no `docker0` IP inter
 
 
 If this value is not `172.17.0.1`, you need to update: 
-* The `issuerURL` the `tenant` configuration in [`configs/main.jsonnet`](/configuration/examples/local/main.jsonnet)
+* The `issuerURL` in the `tenant` section of the configuration in [`configs/main.jsonnet`](/configuration/examples/local/main.jsonnet)
 * Run `make generate` in the root of the [`configurations`](/configuration/Makefile) to regenerate our K8s manifests with the new `issuerURL`
 * Update the `issuer` URL in the Hydra config in [`configs/hydra.yaml`](/configuration/examples/local/configs/hydra.yaml)
 
@@ -236,8 +236,8 @@ We are going to use Grafana to query the data we wrote into Observatorium. To st
 docker run -p 3000:3000 grafana/grafana:7.3.7
 ```
 
-* Now open your web browser and go to `http://localhost:3000`. the default username:password is `admin:admin`.
-* Add a new Prometheus data source with url `http://172.17.0.1:8080/api/metrics/v1/test-oidc`. 
-  * We are using `172.17.0.1`(linux) or `host.docker.internal`(mac) as the host because we are trying to access the `token-refresher`; running on the host, from Grafana; which is running inside a docker container.
+* Now open your web browser and go to `http://localhost:3000`. The default username is `admin` and the default password is `admin`.
+* Add a new Prometheus data source with the URL set to `http://172.17.0.1:8080/api/metrics/v1/test-oidc`.
+  * We are using `172.17.0.1`(linux) or `host.docker.internal`(mac) as the host because we are trying to access the `token-refresher` running on the host, from Grafana which is running inside a docker container.
 
 You can now go the the `Explore` tab to run queries against the Observatorium API.

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -75,11 +75,13 @@ kind create cluster
 [OIDC (OpenID Connect)](https://openid.net/connect/) is a popular authentication often available in your company or major cloud providers. For local purposes we will run our own OIDC provider to handle authentication. We are going to use ORY Hydra for that. First download and extract the binary release from [here](https://github.com/ory/hydra/releases/download/v1.9.1/hydra_1.9.1-sqlite_linux_64bit.tar.gz).
 
 **Linux**
+
 ```bash
 curl -L "https://github.com/ory/hydra/releases/download/v1.9.1/hydra_1.9.1-sqlite_linux_64bit.tar.gz" | tar -xzf - -C tmp/bin hydra
 ```
 
 **MacOS**
+
 ```bash
 curl -L "https://github.com/ory/hydra/releases/download/v1.9.1/hydra_1.9.1-sqlite_macos_64bit.tar.gz" | tar -xzf - -C /tmp/bin hydra
 ```
@@ -91,25 +93,27 @@ strategies:
   access_token: jwt
 urls:
   self:
-    issuer: http://172.17.0.1:4444/
+    issuer: http://docker.for.mac.localhost:4444/
+
 ```
 
 #### Accessing Hydra from inside our cluster
-We will be running `hydra` outside the cluster to simulate an external tenant, but we need to access `hydra`(running on the host) from inside the cluster(running inside docker). 
+
+We will be running `hydra` outside the cluster to simulate an external tenant, but we need to access `hydra`(running on the host) from inside the cluster(running inside docker).
 
 **Linux**
 
 As our K8s cluster is running inside Docker containers, we can use the IP address of the `docker0` interface to access the host from inside the containers. In most cases this IP address will be `172.17.0.1` but you can find yours using:
+
 ```bash
 ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1
 ```
 
-**MacOS** 
+**MacOS**
 
-If you are using Kind with Docker Desktop on Mac, there is no `docker0` IP interface accessible on the host; this is because Docker-for-mac [containers run via a Virtual Machine (HyperKit)](https://docs.docker.com/desktop/mac/install/). As a workaround, Docker provides a special DNS entry  [`host.docker.internal`](https://docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds).
+If you are using Kind with Docker Desktop on Mac, there is no `docker0` IP interface accessible on the host; this is because Docker-for-mac [containers run via a Virtual Machine (HyperKit)](https://docs.docker.com/desktop/mac/install/). As a workaround, Docker provides a special DNS entry [`host.docker.internal`](https://docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds).
 
-
-If this value is not `172.17.0.1`, you need to update: 
+If this value is not `172.17.0.1`, you need to update:
 * The `issuerURL` in the `tenant` section of the configuration in [`configs/main.jsonnet`](/configuration/examples/local/main.jsonnet)
 * Run `make generate` in the root of the [`configurations`](/configuration/Makefile) to regenerate our K8s manifests with the new `issuerURL`
 * Update the `issuer` URL in the Hydra config in [`configs/hydra.yaml`](/configuration/examples/local/configs/hydra.yaml)
@@ -193,12 +197,14 @@ Take a look at the [Prometheus first steps](https://prometheus.io/docs/introduct
 Download the Prometheus binary for [Linux](https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.linux-amd64.tar.gz) [MacOS](https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.darwin-amd64.tar.gz).
 
 **Linux**
+
 ```bash
 curl -L "https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.linux-amd64.tar.gz" | tar -xzf - -C tmp prometheus-2.24.1.linux-amd64/prometheus
 mv ./tmp/prometheus-2.24.1.linux-amd64/prometheus ./tmp/bin/
 ```
 
 **MacOS**
+
 ```bash
 curl -L "https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.darwin-amd64.tar.gz" | tar -xzf - -C tmp prometheus-2.24.1.linux-amd64/prometheus
 mv ./tmp/prometheus-2.24.1.linux-amd64/prometheus ./tmp/bin/

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -110,7 +110,7 @@ If you are using Kind with Docker Desktop on Mac, there is no `docker0` IP inter
 
 
 If this value is not `172.17.0.1`, you need to update: 
-* The `issuerURL` the `tenant` configuration in [`configs/main.jsonnet`](/configuration/examples/local/main.jsonnet#L5)
+* The `issuerURL` the `tenant` configuration in [`configs/main.jsonnet`](/configuration/examples/local/main.jsonnet)
 * Run `make generate` in the root of the [`configurations`](/configuration/Makefile) to regenerate our K8s manifests with the new `issuerURL`
 * Update the `issuer` URL in the Hydra config in [`configs/hydra.yaml`](/configuration/examples/local/configs/hydra.yaml)
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -74,8 +74,14 @@ kind create cluster
 
 [OIDC (OpenID Connect)](https://openid.net/connect/) is a popular authentication often available in your company or major cloud providers. For local purposes we will run our own OIDC provider to handle authentication. We are going to use ORY Hydra for that. First download and extract the binary release from [here](https://github.com/ory/hydra/releases/download/v1.9.1/hydra_1.9.1-sqlite_linux_64bit.tar.gz).
 
+**Linux**
 ```bash
 curl -L "https://github.com/ory/hydra/releases/download/v1.9.1/hydra_1.9.1-sqlite_linux_64bit.tar.gz" | tar -xzf - -C tmp/bin hydra
+```
+
+**MacOS**
+```bash
+curl -L "https://github.com/ory/hydra/releases/download/v1.9.1/hydra_1.9.1-sqlite_macos_64bit.tar.gz" | tar -xzf - -C /tmp/bin hydra
 ```
 
 The configuration file for `hydra` is present in [`configs/hydra.yaml`](/configuration/examples/local/configs/hydra.yaml).
@@ -88,13 +94,25 @@ urls:
     issuer: http://172.17.0.1:4444/
 ```
 
-We will be running `hydra` outside the cluster to simulate an external tenant, but we need to access `hydra` from inside the cluster. As our K8s cluster is running inside Docker containers, we can use the ip address of `docker0` interface to access host from inside the containers. In most cases it will be `172.17.0.1` but you can find yours using
+#### Accessing Hydra from inside our cluster
+We will be running `hydra` outside the cluster to simulate an external tenant, but we need to access `hydra`(running on the host) from inside the cluster(running inside docker). 
 
+**Linux**
+
+As our K8s cluster is running inside Docker containers, we can use the ip address of `docker0` interface to access host from inside the containers. In most cases it will be `172.17.0.1` but you can find yours using:
 ```bash
 ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1
 ```
 
-If this value is not `172.17.0.1`, you need to update the `issuer` URL in the config file for hydra.
+**MacOS** 
+
+If you are using Kind with Docker Desktop on Mac, there is no `docker0` IP interface accessible on the host; this is because Docker-for-mac [containers run via a Virtual Machine (HyperKit)](https://docs.docker.com/desktop/mac/install/). As a workaround, Docker provides a special DNS entry  [`host.docker.internal`](https://docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds).
+
+
+If this value is not `172.17.0.1`, you need to update: 
+* The `issuerURL` the `tenant` configuration in [`configs/main.jsonnet`](/configuration/examples/local/main.jsonnet#L5)
+* Run `make generate` in the root of the [`configurations`](/configuration/Makefile) to regenerate our K8s manifests with the new `issuerURL`
+* Update the `issuer` URL in the Hydra config in [`configs/hydra.yaml`](/configuration/examples/local/configs/hydra.yaml)
 
 Next step is to run `hydra`.
 
@@ -172,10 +190,17 @@ The token issued by the OIDC providers often have a small validity, but it can b
 
 Take a look at the [Prometheus first steps](https://prometheus.io/docs/introduction/first_steps/) to get a quick overview of how to get started. By default Prometheus stores the data locally in form of TSDB blocks. We will configure it to remote write this data to Observatorium. As we know that the write endpoint is protected, we will write to the token-refresher proxy, and the proxy in turn will forward this data to the Observatorium API with proper tokens.
 
-Download the Prometheus binary from [here](https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.linux-amd64.tar.gz).
+Download the Prometheus binary for [Linux](https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.linux-amd64.tar.gz) [MacOS](https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.darwin-amd64.tar.gz).
 
+**Linux**
 ```bash
 curl -L "https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.linux-amd64.tar.gz" | tar -xzf - -C tmp prometheus-2.24.1.linux-amd64/prometheus
+mv ./tmp/prometheus-2.24.1.linux-amd64/prometheus ./tmp/bin/
+```
+
+**MacOS**
+```bash
+curl -L "https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.darwin-amd64.tar.gz" | tar -xzf - -C tmp prometheus-2.24.1.linux-amd64/prometheus
 mv ./tmp/prometheus-2.24.1.linux-amd64/prometheus ./tmp/bin/
 ```
 
@@ -211,7 +236,8 @@ We are going to use Grafana to query the data we wrote into Observatorium. To st
 docker run -p 3000:3000 grafana/grafana:7.3.7
 ```
 
-- Now open your web browser and go to `http://localhost:3000`. the default username:password is `admin:admin`.
-- Add a new Prometheus data source with url `http://172.17.0.1:8080/api/metrics/v1/test-oidc`. We are using `172.17.0.1` as the host because we are trying to access the `token-refresher` running on the host from Grafana, which is running inside a docker container.
+* Now open your web browser and go to `http://localhost:3000`. the default username:password is `admin:admin`.
+* Add a new Prometheus data source with url `http://172.17.0.1:8080/api/metrics/v1/test-oidc`. 
+  * We are using `172.17.0.1`(linux) or `host.docker.internal`(mac) as the host because we are trying to access the `token-refresher`; running on the host, from Grafana; which is running inside a docker container.
 
 You can now go the the `Explore` tab to run queries against the Observatorium API.

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -93,8 +93,7 @@ strategies:
   access_token: jwt
 urls:
   self:
-    issuer: http://docker.for.mac.localhost:4444/
-
+    issuer: http://172.17.0.1:4444/
 ```
 
 #### Accessing Hydra from inside our cluster


### PR DESCRIPTION
If you are using Kind with Docker Desktop on Mac, there is no `docker0` IP interface accessible on the host; this is because Docker-for-mac [containers run via a Virtual Machine (HyperKit)](https://docs.docker.com/desktop/mac/install/). As a workaround, Docker provides a special DNS entry [`host.docker.internal`](https://docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds).

I've updated the docs with this detail to allow MacOS users to run Observatorium locally without issue, i've also added macos CDN links for prom and hydra too. 