### PR TITLE
Use the new custom resource definition of prometheus operator

### DIFF
--- a/configuration/tests/e2e.sh
+++ b/configuration/tests/e2e.sh
@@ -26,8 +26,8 @@ dex() {
 }
 
 deploy() {
-    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
-    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/setup/0servicemonitorCustomResourceDefinition.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
     $KUBECTL create ns observatorium-minio || true
     $KUBECTL create ns observatorium || true
     dex


### PR DESCRIPTION
This is used by the e2e tests, the path to the custom resource
definitions has been changed.