### PR TITLE
Fix e2e test

### DIFF
--- a/configuration/tests/e2e.sh
+++ b/configuration/tests/e2e.sh
@@ -26,8 +26,8 @@ dex() {
 }
 
 deploy() {
-    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
-    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/0servicemonitorCustomResourceDefinition.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
     $KUBECTL create ns observatorium-minio || true
     $KUBECTL create ns observatorium || true
     dex


### PR DESCRIPTION
Filenames for kube-prometheus manifests were [changed](https://github.com/prometheus-operator/kube-prometheus/commit/06fd109ebc305b605ee11e62995205d96611d255#diff-98941af9c0c41acea5b7889d24356c9b2b988b07d2e1590089677073c6c938b0) recently, which causes e2e tests to fail (e.g [here](https://app.circleci.com/pipelines/github/observatorium/observatorium/703/workflows/7b121720-0ff6-4556-b3f7-040cf6572e32/jobs/3327) & [here](https://app.circleci.com/pipelines/github/observatorium/observatorium/705/workflows/667e14c1-3089-4fd8-9971-e78d66c5a557/jobs/3332)).