### PR TITLE
configuration/tests: pin external manifests

### DIFF
--- a/configuration/tests/e2e.sh
+++ b/configuration/tests/e2e.sh
@@ -26,8 +26,8 @@ dex() {
 }
 
 deploy() {
-    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
-    $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/06fd109ebc305b605ee11e62995205d96611d255/manifests/setup/0servicemonitorCustomResourceDefinition.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/06fd109ebc305b605ee11e62995205d96611d255/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
     $KUBECTL create ns observatorium-minio || true
     $KUBECTL create ns observatorium || true
     dex


### PR DESCRIPTION
This commit fixes the e2e tests for this repository. Currently, the e2e
tests depend on some external manifests located at the tip of the
Prometheus Operator repository. These manifests were renamed 2 weeks
ago, which broke our tests. In order to prevent future fragility, this
commit pins the manifests to a specific commit.

unblocks #446 

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>