### PR TITLE
make imagepullpolicy configurable.

### DIFF
--- a/configuration/components/memcached.libsonnet
+++ b/configuration/components/memcached.libsonnet
@@ -26,6 +26,7 @@ local defaults = {
   imagePullPolicy: 'IfNotPresent',
   exporterVersion: error 'must provide exporter version',
   exporterImage: error 'must provide exporter image',
+  exporterImagePullPolicy: 'IfNotPresent',
   replicas: error 'must provide replicas',
   resources: {},
   serviceMonitor: false,
@@ -130,7 +131,7 @@ function(params) {
     local exporter = {
       name: 'exporter',
       image: mc.config.exporterImage,
-      imagePullPolicy: mc.config.imagePullPolicy,
+      imagePullPolicy: mc.config.exporterImagePullPolicy,
       args: [
         '--memcached.address=localhost:%d' % mc.service.spec.ports[0].port,
         '--web.listen-address=0.0.0.0:%d' % mc.service.spec.ports[1].port,

--- a/configuration/components/thanos.libsonnet
+++ b/configuration/components/thanos.libsonnet
@@ -99,6 +99,8 @@ local defaults = {
 
   rule: {
     replicas: 1,
+    reloaderImage: 'jimmidyson/configmap-reload:v0.5.0',
+    reloaderImagePullPolicy: 'IfNotPresent',
     volumeClaimTemplate: {
       spec: {
         accessModes: ['ReadWriteOnce'],
@@ -165,6 +167,7 @@ function(params) {
     namespace: thanos.config.namespace,
     commonLabels+:: thanos.config.commonLabels,
     image: thanos.config.image,
+    imagePullPolicy: thanos.config.imagePullPolicy,
     version: thanos.config.version,
     deduplicationReplicaLabels: thanos.config.deduplicationReplicaLabels,
     objectStorageConfig: thanos.config.objectStorageConfig,
@@ -200,6 +203,7 @@ function(params) {
     namespace: thanos.config.namespace,
     commonLabels+:: thanos.config.commonLabels,
     image: thanos.config.image,
+    imagePullPolicy: thanos.config.imagePullPolicy,
     version: thanos.config.version,
     replicaLabels: thanos.config.replicaLabels,
     objectStorageConfig: thanos.config.objectStorageConfig,
@@ -212,6 +216,9 @@ function(params) {
     namespace: thanos.config.namespace,
     commonLabels+:: thanos.config.commonLabels,
     image: thanos.config.image,
+    imagePullPolicy: thanos.config.imagePullPolicy,
+    reloaderImage: thanos.config.rule.reloaderImage,
+    reloaderImagePullPolicy: thanos.config.rule.reloaderImagePullPolicy,
     version: thanos.config.version,
     objectStorageConfig: thanos.config.objectStorageConfig,
     queriers: ['dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace]],
@@ -222,6 +229,7 @@ function(params) {
     namespace: thanos.config.namespace,
     commonLabels+:: thanos.config.commonLabels,
     image: thanos.config.image,
+    imagePullPolicy: thanos.config.imagePullPolicy,
     version: thanos.config.version,
     objectStorageConfig: thanos.config.objectStorageConfig,
     replicas: 1,
@@ -259,6 +267,7 @@ function(params) {
     namespace: thanos.config.namespace,
     commonLabels+:: thanos.config.commonLabels,
     image: thanos.config.image,
+    imagePullPolicy: thanos.config.imagePullPolicy,
     version: thanos.config.version,
     stores: [
       'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
@@ -275,6 +284,7 @@ function(params) {
     namespace: thanos.config.namespace,
     commonLabels+:: thanos.config.commonLabels,
     image: thanos.config.image,
+    imagePullPolicy: thanos.config.imagePullPolicy,
     version: thanos.config.version,
     downstreamURL: 'http://%s.%s.svc.cluster.local.:%d' % [
       thanos.query.service.metadata.name,

--- a/configuration/examples/base/manifests/api-deployment.yaml
+++ b/configuration/examples/base/manifests/api-deployment.yaml
@@ -34,14 +34,15 @@ spec:
       - args:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
+        - --log.level=warn
         - --metrics.read.endpoint=http://observatorium-xyz-thanos-query-frontend.observatorium.svc.cluster.local:9090
         - --metrics.write.endpoint=http://observatorium-xyz-thanos-receive.observatorium.svc.cluster.local:19291
-        - --log.level=warn
         - --logs.read.endpoint=http://observatorium-xyz-loki-query-frontend-http.observatorium.svc.cluster.local:3100
         - --logs.tail.endpoint=http://observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
         image: quay.io/observatorium/api:main-2021-11-30-v0.1.2-106-g2adff5f
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/configuration/examples/base/manifests/thanos-compact-service.yaml
+++ b/configuration/examples/base/manifests/thanos-compact-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/configuration/examples/base/manifests/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/base/manifests/thanos-compact-statefulSet.yaml
@@ -27,6 +27,24 @@ spec:
         app.kubernetes.io/part-of: observatorium
         app.kubernetes.io/version: v0.24.0
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - observatorium-xyz
+              namespaces:
+              - observatorium
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact
@@ -53,6 +71,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -77,6 +96,8 @@ spec:
         - mountPath: /var/thanos/compact
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/base/manifests/thanos-query-deployment.yaml
+++ b/configuration/examples/base/manifests/thanos-query-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -83,6 +84,8 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/base/manifests/thanos-query-frontend-deployment.yaml
+++ b/configuration/examples/base/manifests/thanos-query-frontend-deployment.yaml
@@ -83,6 +83,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -103,6 +104,8 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/base/manifests/thanos-receive-controller-deployment.yaml
+++ b/configuration/examples/base/manifests/thanos-receive-controller-deployment.yaml
@@ -38,9 +38,13 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: quay.io/observatorium/thanos-receive-controller:master-2021-04-28-ee165b6
+        imagePullPolicy: IfNotPresent
         name: thanos-receive-controller
         ports:
         - containerPort: 8080
           name: http
         resources: {}
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
       serviceAccount: observatorium-xyz-thanos-receive-controller

--- a/configuration/examples/base/manifests/thanos-receive-default-statefulSet.yaml
+++ b/configuration/examples/base/manifests/thanos-receive-default-statefulSet.yaml
@@ -73,12 +73,12 @@ spec:
         - --http-address=0.0.0.0:10902
         - --remote-write.address=0.0.0.0:19291
         - --receive.replication-factor=1
-        - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/receive
         - --tsdb.retention=4d
-        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --label=replica="$(NAME)"
         - --label=receive="true"
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         env:
         - name: NAME
@@ -89,16 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        - name: HOST_IP_ADDRESS
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -129,6 +130,8 @@ spec:
           readOnly: false
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/base/manifests/thanos-rule-service.yaml
+++ b/configuration/examples/base/manifests/thanos-rule-service.yaml
@@ -18,6 +18,9 @@ spec:
   - name: http
     port: 10902
     targetPort: 10902
+  - name: reloader
+    port: 9533
+    targetPort: 9533
   selector:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: observatorium-xyz

--- a/configuration/examples/base/manifests/thanos-rule-statefulSet.yaml
+++ b/configuration/examples/base/manifests/thanos-rule-statefulSet.yaml
@@ -56,6 +56,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 24
           httpGet:
@@ -69,6 +70,8 @@ spec:
           name: grpc
         - containerPort: 10902
           name: http
+        - containerPort: 9533
+          name: reloader
         readinessProbe:
           failureThreshold: 18
           httpGet:
@@ -83,6 +86,8 @@ spec:
         - mountPath: /var/thanos/rule
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/base/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/base/manifests/thanos-store-shard0-statefulSet.yaml
@@ -113,6 +113,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,6 +140,8 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/dev/manifests/api-deployment.yaml
+++ b/configuration/examples/dev/manifests/api-deployment.yaml
@@ -34,9 +34,9 @@ spec:
       - args:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
+        - --log.level=warn
         - --metrics.read.endpoint=http://observatorium-xyz-thanos-query-frontend.observatorium.svc.cluster.local:9090
         - --metrics.write.endpoint=http://observatorium-xyz-thanos-receive.observatorium.svc.cluster.local:19291
-        - --log.level=warn
         - --logs.read.endpoint=http://observatorium-xyz-loki-query-frontend-http.observatorium.svc.cluster.local:3100
         - --logs.tail.endpoint=http://observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
@@ -44,6 +44,7 @@ spec:
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
         image: quay.io/observatorium/api:main-2021-11-30-v0.1.2-106-g2adff5f
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/configuration/examples/dev/manifests/thanos-compact-service.yaml
+++ b/configuration/examples/dev/manifests/thanos-compact-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/configuration/examples/dev/manifests/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/thanos-compact-statefulSet.yaml
@@ -27,6 +27,24 @@ spec:
         app.kubernetes.io/part-of: observatorium
         app.kubernetes.io/version: v0.24.0
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - observatorium-xyz
+              namespaces:
+              - observatorium
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact
@@ -53,6 +71,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -77,6 +96,8 @@ spec:
         - mountPath: /var/thanos/compact
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/dev/manifests/thanos-query-deployment.yaml
+++ b/configuration/examples/dev/manifests/thanos-query-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -83,6 +84,8 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/dev/manifests/thanos-query-frontend-deployment.yaml
+++ b/configuration/examples/dev/manifests/thanos-query-frontend-deployment.yaml
@@ -83,6 +83,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -103,6 +104,8 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/dev/manifests/thanos-receive-controller-deployment.yaml
+++ b/configuration/examples/dev/manifests/thanos-receive-controller-deployment.yaml
@@ -38,9 +38,13 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: quay.io/observatorium/thanos-receive-controller:master-2021-04-28-ee165b6
+        imagePullPolicy: IfNotPresent
         name: thanos-receive-controller
         ports:
         - containerPort: 8080
           name: http
         resources: {}
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
       serviceAccount: observatorium-xyz-thanos-receive-controller

--- a/configuration/examples/dev/manifests/thanos-receive-default-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/thanos-receive-default-statefulSet.yaml
@@ -73,12 +73,12 @@ spec:
         - --http-address=0.0.0.0:10902
         - --remote-write.address=0.0.0.0:19291
         - --receive.replication-factor=1
-        - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/receive
         - --tsdb.retention=4d
-        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --label=replica="$(NAME)"
         - --label=receive="true"
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         env:
         - name: NAME
@@ -89,16 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        - name: HOST_IP_ADDRESS
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -129,6 +130,8 @@ spec:
           readOnly: false
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/dev/manifests/thanos-rule-service.yaml
+++ b/configuration/examples/dev/manifests/thanos-rule-service.yaml
@@ -18,6 +18,9 @@ spec:
   - name: http
     port: 10902
     targetPort: 10902
+  - name: reloader
+    port: 9533
+    targetPort: 9533
   selector:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: observatorium-xyz

--- a/configuration/examples/dev/manifests/thanos-rule-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/thanos-rule-statefulSet.yaml
@@ -56,6 +56,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 24
           httpGet:
@@ -69,6 +70,8 @@ spec:
           name: grpc
         - containerPort: 10902
           name: http
+        - containerPort: 9533
+          name: reloader
         readinessProbe:
           failureThreshold: 18
           httpGet:
@@ -83,6 +86,8 @@ spec:
         - mountPath: /var/thanos/rule
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/dev/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/thanos-store-shard0-statefulSet.yaml
@@ -113,6 +113,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,6 +140,8 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/local/manifests/api-deployment.yaml
+++ b/configuration/examples/local/manifests/api-deployment.yaml
@@ -34,9 +34,9 @@ spec:
       - args:
         - --web.listen=0.0.0.0:8080
         - --web.internal.listen=0.0.0.0:8081
+        - --log.level=warn
         - --metrics.read.endpoint=http://observatorium-xyz-thanos-query-frontend.observatorium.svc.cluster.local:9090
         - --metrics.write.endpoint=http://observatorium-xyz-thanos-receive.observatorium.svc.cluster.local:19291
-        - --log.level=warn
         - --logs.read.endpoint=http://observatorium-xyz-loki-query-frontend-http.observatorium.svc.cluster.local:3100
         - --logs.tail.endpoint=http://observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
@@ -44,6 +44,7 @@ spec:
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
         image: quay.io/observatorium/api:main-2021-11-30-v0.1.2-106-g2adff5f
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/configuration/examples/local/manifests/thanos-compact-service.yaml
+++ b/configuration/examples/local/manifests/thanos-compact-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-thanos-compact
   namespace: observatorium
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/configuration/examples/local/manifests/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/local/manifests/thanos-compact-statefulSet.yaml
@@ -27,6 +27,24 @@ spec:
         app.kubernetes.io/part-of: observatorium
         app.kubernetes.io/version: v0.24.0
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - observatorium-xyz
+              namespaces:
+              - observatorium
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact
@@ -53,6 +71,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -77,6 +96,8 @@ spec:
         - mountPath: /var/thanos/compact
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/local/manifests/thanos-query-deployment.yaml
+++ b/configuration/examples/local/manifests/thanos-query-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -83,6 +84,8 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/local/manifests/thanos-query-frontend-deployment.yaml
+++ b/configuration/examples/local/manifests/thanos-query-frontend-deployment.yaml
@@ -83,6 +83,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -103,6 +104,8 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/local/manifests/thanos-receive-controller-deployment.yaml
+++ b/configuration/examples/local/manifests/thanos-receive-controller-deployment.yaml
@@ -38,9 +38,13 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: quay.io/observatorium/thanos-receive-controller:master-2021-04-28-ee165b6
+        imagePullPolicy: IfNotPresent
         name: thanos-receive-controller
         ports:
         - containerPort: 8080
           name: http
         resources: {}
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
       serviceAccount: observatorium-xyz-thanos-receive-controller

--- a/configuration/examples/local/manifests/thanos-receive-default-statefulSet.yaml
+++ b/configuration/examples/local/manifests/thanos-receive-default-statefulSet.yaml
@@ -73,12 +73,12 @@ spec:
         - --http-address=0.0.0.0:10902
         - --remote-write.address=0.0.0.0:19291
         - --receive.replication-factor=1
-        - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/receive
         - --tsdb.retention=4d
-        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --label=replica="$(NAME)"
         - --label=receive="true"
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --receive.local-endpoint=$(NAME).observatorium-xyz-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         env:
         - name: NAME
@@ -89,16 +89,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        - name: HOST_IP_ADDRESS
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -129,6 +130,8 @@ spec:
           readOnly: false
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/local/manifests/thanos-rule-service.yaml
+++ b/configuration/examples/local/manifests/thanos-rule-service.yaml
@@ -18,6 +18,9 @@ spec:
   - name: http
     port: 10902
     targetPort: 10902
+  - name: reloader
+    port: 9533
+    targetPort: 9533
   selector:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: observatorium-xyz

--- a/configuration/examples/local/manifests/thanos-rule-statefulSet.yaml
+++ b/configuration/examples/local/manifests/thanos-rule-statefulSet.yaml
@@ -56,6 +56,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 24
           httpGet:
@@ -69,6 +70,8 @@ spec:
           name: grpc
         - containerPort: 10902
           name: http
+        - containerPort: 9533
+          name: reloader
         readinessProbe:
           failureThreshold: 18
           httpGet:
@@ -83,6 +86,8 @@ spec:
         - mountPath: /var/thanos/rule
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/examples/local/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/local/manifests/thanos-store-shard0-statefulSet.yaml
@@ -113,6 +113,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.24.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,6 +140,8 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/configuration/jsonnetfile.lock.json
+++ b/configuration/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "d7b6867af17766826540ef9f7b06c84210d0481d",
-      "sum": "Z86CgnoTybhpdQKWc2ptURmps1d9Qxhec0/IK6v71kY=",
+      "version": "1852b0f706ad7e5db340421977ab5b5b8c8e2087",
+      "sum": "PeiropwPLWC8g7o0xaH0clwLoYHTngNJKtaTaEh+hc0=",
       "name": "observatorium-api"
     },
     {
@@ -19,8 +19,8 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "c4e7a4a2371b8297d3c8ebccdd247e2a0b5214d4",
-      "sum": "sqF9titAn3N2HHKY9mCzbZ+d/xL5ZBQ/ej/t190jY6o=",
+      "version": "cd12a419fc00eeb354d1f48e3077648222b16c07",
+      "sum": "0yZzNAcHQER0vE90d4iur3mYSitIhe8DhIFBeWdlb6k=",
       "name": "thanos-receive-controller"
     },
     {
@@ -30,7 +30,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "03ef2f2bb89be1dbf45078fef371441d162df679",
+      "version": "21b9125fa700ce2f2472caef720086179329b33e",
       "sum": "0FKabnXd0rMeu8YpkkopEOknqBf5PLq/DIIDd0ve7cU=",
       "name": "up"
     },
@@ -41,8 +41,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "f53ad9856c6f765989ea76ba8eff8dd1e77186b7",
-      "sum": "1wMHM/+NvluUAxS5cBW2c6APEKQNQYLYnv1ZCE1R3/A="
+      "version": "7e8fc8c8b3129c7a822e61e7fb109596f410e8c5",
+      "sum": "K3y2JG3FCgXv3zuiaUl2BIfwODpahnb9wphykDreoyI="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This is a follow up PR for:

- https://github.com/observatorium/observatorium/pull/446
- https://github.com/observatorium/thanos-receive-controller/pull/79
- https://github.com/observatorium/api/pull/202
- https://github.com/thanos-io/kube-thanos/pull/261

updated the jsonnet dependencies so that the components are update-to-date, also make sure the passed in parameters will override the default values.
You may also see some other new fields update, for example, pod affinity support, etc, they are included with jsonnet dependencies update.

Signed-off-by: morvencao <lcao@redhat.com>