### PR TITLE
Add proposal for `obsctl`

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -4,3 +4,6 @@ validators:
   # ignore links for release tarballs
   - regex: 'releases\/download'
     type: 'ignore'
+  # Always returns 403.
+  - regex: 'cloudflare\.com'
+    type: 'ignore'

--- a/docs/proposals/20220215-obsctl.md
+++ b/docs/proposals/20220215-obsctl.md
@@ -9,13 +9,13 @@
 * **Other docs:**
   * None
 
-## Why
+## TL;DR
 
 We can interact with [Observatorium API](https://github.com/observatorium/api) with a convenient and dedicated CLI, which provides capabilities to persist auth data, and allows us to easily & quickly get up and running with our operations.
 
 ## Pitfalls of Current Solution
 
-Currently, we need to manually run [token-refresher](https://github.com/observatorium/token-refresher) with [OIDC](https://openid.net/connect/) information for a particular tenant, and then make cURL requests through that. This is not optimal and generally confusing/trickier for users, both old and new.
+Currently, we do not have a simple and convenient way to interact with the Observatorium API from the command line. Manually crafting cURL commands while authenticating with OIDC or mTLS is not an optimal experience and generally confusing/trickier for users, both old and new.
 
 ## Goals
 
@@ -28,7 +28,7 @@ obsctl will,
 
 ## Non-Goals
 
-* Adding and dynamically configuring tenants through obsctl (No such admin API is available within Observatorium, nor is it planned)
+* Enabling Observatorium administration via obsctl
 
 ## Audience of this proposal
 
@@ -36,32 +36,36 @@ Observatorium Devs and Users.
 
 ## How
 
-As obsctl is a CLI, authentication options (OIDC) need to be persisted across sessions. obsctl aims to achieve this by saving those configurations locally at some configuration directory and maintaining a "current" tenant.
+As obsctl is a CLI, authentication options (OIDC) need to be persisted across sessions. obsctl aims to achieve this by saving those configurations locally at some configuration directory and maintaining a "current" tenant & a "current" instance of Observatorium, which we can refer to as "context".
 
-The "current" tenant will basically represent the logged-in tenant and all operations will be done based on this "current" tenant configuration. In case, the "current" tenant is empty, i.e, there is no tenant currently logged-in, obsctl will error out.
+The "current context" will basically represent the logged-in tenant and the Observatorium API endpoint which the tenant is allowed to use. All operations will be done based on this "current context" configuration. In case, the "current context" is empty, i.e, there is no tenant currently logged-in or no API provided, obsctl will error out.
 
-obsctl will also allow the user to switch from the "current" tenant to another one. This can be achieved by creating a map of tenant configurations that are uniquely referenceable.
+obsctl will also allow the user to switch from the "current context" to another one. This can be achieved by creating a map of tenant configurations and API configurations that are uniquely referenceable.
+
+For OIDC/OAuth2 based authentication, obsctl will try to fetch refresh token from SSO service (if supported) and store it locally as it has longer validity, and automatically refresh the access token using that when needed.
 
 ### Authentication Commands to be supported by obsctl
 
-* `login <OIDC flags>`: Login as a tenant and save their configuration locally.
-* `logout`: Logout current tenant.
-* `switch <tenant>`: Switch from one tenant to another.
-* `current`: Display the “current” tenant.
+* `login --tenant --api <name/URL> <OIDC flags> `: Login as a tenant and save their configuration locally.
+  * `--name`: Optional flag to override the name used to refer the tenant.
+  * `--api-name`: Optional flag to override the name used to refer the api. By default the hostname of the URL is used.
+* `context api add --url <URL> --name <api name>` : Add a referrable instance of Observatorium.
+* `context switch <api name>/<tenant>`: Switch from one context to another.
+* `context current`: Display the “current” context.
 
 Initially, obsctl aims to support one-off metrics-based operations for users.
 
 ### Metric-based Commands to be supported by obsctl
 
-* `rules get`: Get configured Rules for a tenant (YAML, hits `api/v1/rules/raw`).
-* `rules set <config>`: Set Rules for a tenant by passing in Rule file.
-* `read rules`: Read rules for a tenant. (JSON, hits `api/v1/rules`).
-* `read series`: Read series for a tenant.
-* `read labels`: Read labels for a tenant.
-* `query <PromQL query>`: Query data for a particular tenant (JSON).
+* `metrics get rules.raw`: Get configured Rules for a tenant (YAML, hits `api/v1/rules/raw`).
+* `metrics get rules`: Read rules for a tenant. (JSON, hits `api/v1/rules`).
+* `metrics get series`: Read series for a tenant.
+* `metrics get labels`: Read labels for a tenant.
+* `metrics set --rule.file=<rules-config>`: Set Rules for a tenant by passing in Rule file.
+* `metrics query <PromQL query>`: Query data for a particular tenant (JSON).
 
 Additionally, obsctl will also provide statistical information (such as time taken, response size) about the performed operations along with the result, which might be useful for users willing to debug their instances of Observatorium.
 
 ## Alternatives
 
-* Continuing with the existing process of using token-refresher and cURL and documenting that in detail.
+* Continuing with the existing process of manually crafting cURL requests and documenting that in detail.

--- a/docs/proposals/20220215-obsctl.md
+++ b/docs/proposals/20220215-obsctl.md
@@ -36,24 +36,29 @@ Observatorium Devs and Users.
 
 ## How
 
-As obsctl is a CLI, authentication options (OIDC) need to be persisted across sessions. obsctl aims to achieve this by saving those configurations locally at some configuration directory and maintaining a "current" tenant & a "current" instance of Observatorium, which we can refer to as "context".
+As obsctl is a CLI, authentication options (OIDC) need to be persisted across sessions. obsctl aims to achieve this by saving those configurations locally at a configuration directory and maintaining a "current" tenant & a "current" instance of Observatorium, which we can refer to as "context".
 
 The "current context" will basically represent the logged-in tenant and the Observatorium API endpoint which the tenant is allowed to use. All operations will be done based on this "current context" configuration. In case, the "current context" is empty, i.e, there is no tenant currently logged-in or no API provided, obsctl will error out.
 
-obsctl will also allow the user to switch from the "current context" to another one. This can be achieved by creating a map of tenant configurations and API configurations that are uniquely referenceable.
+obsctl will also allow the user to switch from the "current context" to another one. This can be achieved by creating a map of API configurations, each having tenants, that are uniquely referenceable.
 
-For OIDC/OAuth2 based authentication, obsctl will try to fetch refresh token from SSO service (if supported) and store it locally as it has longer validity, and automatically refresh the access token using that when needed.
+For OIDC/OAuth2 based authentication, obsctl will try to fetch access token from SSO service (if supported) and store it locally, and automatically refresh the access token if the locally saved token expires.
+
+Other auth flows such as [OIDC Device Flow](https://oauth.net/2/device-flow/) or [mTLS](https://www.cloudflare.com/en-in/learning/access-management/what-is-mutual-tls/) will be added as optional flags, so that users can use flows of their choice.
+
+The configuration will be saved at a path like `os.UserConfigDir()/obsctl/config.json`. Here [os.UserConfigDir](https://pkg.go.dev/os#UserConfigDir) is used to keep obsctl consistent across platforms.
 
 ### Authentication Commands to be supported by obsctl
 
 * `login --tenant --api <name/URL> <OIDC flags> `: Login as a tenant and save their configuration locally.
-  * `--name`: Optional flag to override the name used to refer the tenant.
-  * `--api-name`: Optional flag to override the name used to refer the api. By default the hostname of the URL is used.
-* `context api add --url <URL> --name <api name>` : Add a referrable instance of Observatorium.
+  * `--tenant`: The name used to refer to the tenant.
+  * `--api-name`: The name used to refer to the api.
+* `context api add --url <URL> --name <api name>` : Add a referrable instance of Observatorium. If name is not provided then URL hostname is used.
 * `context switch <api name>/<tenant>`: Switch from one context to another.
+* `context list`: List all the possible contexts.
 * `context current`: Display the “current” context.
 
-Initially, obsctl aims to support one-off metrics-based operations for users.
+Initially, obsctl aims to support one-off metrics-based operations for users. Endpoints for other signals can be added later on.
 
 ### Metric-based Commands to be supported by obsctl
 

--- a/docs/proposals/20220215-obsctl.md
+++ b/docs/proposals/20220215-obsctl.md
@@ -58,9 +58,10 @@ Initially, obsctl aims to support one-off metrics-based operations for users.
 ### Metric-based Commands to be supported by obsctl
 
 * `metrics get rules.raw`: Get configured Rules for a tenant (YAML, hits `api/v1/rules/raw`).
-* `metrics get rules`: Read rules for a tenant. (JSON, hits `api/v1/rules`).
-* `metrics get series`: Read series for a tenant.
-* `metrics get labels`: Read labels for a tenant.
+* `metrics get rules <URL params as flags>`: Read rules for a tenant. (JSON, hits `api/v1/rules`).
+* `metrics get series <URL params as flags>`: Read series for a tenant.
+* `metrics get labels <URL params as flags>`: Read labels for a tenant.
+* `metrics get labelvalues <URL params as flags>`: Read label values for a tenant.
 * `metrics set --rule.file=<rules-config>`: Set Rules for a tenant by passing in Rule file.
 * `metrics query <PromQL query>`: Query data for a particular tenant (JSON).
 

--- a/docs/proposals/20220215-obsctl.md
+++ b/docs/proposals/20220215-obsctl.md
@@ -15,7 +15,7 @@ We can interact with [Observatorium API](https://github.com/observatorium/api) w
 
 ## Pitfalls of Current Solution
 
-Currently, we do not have a simple and convenient way to interact with the Observatorium API from the command line. Manually crafting cURL commands while authenticating with OIDC or mTLS is not an optimal experience and generally confusing/trickier for users, both old and new.
+Currently, we do not have a simple and convenient way to interact with the Observatorium API from the command line. Manually crafting cURL commands while authenticating with OIDC or mTLS is not an optimal experience and is generally confusing/trickier for users, both old and new.
 
 ## Goals
 
@@ -28,7 +28,7 @@ obsctl will,
 
 ## Non-Goals
 
-* Enabling Observatorium administration via obsctl
+* Enabling Observatorium administration via obsctl, for example, adding or removing tenants in Observatorium programmatically or generating operators using [rndr](https://github.com/observatorium/rndr)
 
 ## Audience of this proposal
 

--- a/docs/proposals/20220215-obsctl.md
+++ b/docs/proposals/20220215-obsctl.md
@@ -1,0 +1,67 @@
+# obsctl: A CLI to interact with Observatorium
+
+* **Owners:**
+  * `@onprem` `@saswatamcode`
+
+* **Related Tickets:**
+  * https://issues.redhat.com/browse/MON-2199
+
+* **Other docs:**
+  * None
+
+## Why
+
+We can interact with [Observatorium API](https://github.com/observatorium/api) with a convenient and dedicated CLI, which provides capabilities to persist auth data, and allows us to easily & quickly get up and running with our operations.
+
+## Pitfalls of Current Solution
+
+Currently, we need to manually run [token-refresher](https://github.com/observatorium/token-refresher) with [OIDC](https://openid.net/connect/) information for a particular tenant, and then make cURL requests through that. This is not optimal and generally confusing/trickier for users, both old and new.
+
+## Goals
+
+obsctl will,
+* Manage authentication configuration for multiple tenants by saving them locally
+* Allow users to switch between tenants conveniently
+* Configure and view rules for a tenant
+* View series, rules, and labels for a tenant
+* Later on, support more such one-off operations for other domains as well (logs, traces, alert-routing configs)
+
+## Non-Goals
+
+* Adding and dynamically configuring tenants through obsctl (No such admin API is available within Observatorium, nor is it planned)
+
+## Audience of this proposal
+
+Observatorium Devs and Users.
+
+## How
+
+As obsctl is a CLI, authentication options (OIDC) need to be persisted across sessions. obsctl aims to achieve this by saving those configurations locally at some configuration directory and maintaining a "current" tenant.
+
+The "current" tenant will basically represent the logged-in tenant and all operations will be done based on this "current" tenant configuration. In case, the "current" tenant is empty, i.e, there is no tenant currently logged-in, obsctl will error out.
+
+obsctl will also allow the user to switch from the "current" tenant to another one. This can be achieved by creating a map of tenant configurations that are uniquely referenceable.
+
+### Authentication Commands to be supported by obsctl
+
+* `login <OIDC flags>`: Login as a tenant and save their configuration locally.
+* `logout`: Logout current tenant.
+* `switch <tenant>`: Switch from one tenant to another.
+* `current`: Display the “current” tenant.
+
+Initially, obsctl aims to support one-off metrics-based operations for users.
+
+### Metric-based Commands to be supported by obsctl
+
+* `rules get`: Get configured Rules for a tenant (YAML, hits `api/v1/rules/raw`).
+* `rules set <config>`: Set Rules for a tenant by passing in Rule file.
+* `read rules`: Read rules for a tenant. (JSON, hits `api/v1/rules`).
+* `read series`: Read series for a tenant.
+* `read labels`: Read labels for a tenant.
+* `query <PromQL query>`: Query data for a particular tenant (JSON).
+
+Additionally, obsctl will also provide statistical information (such as time taken, response size) about the performed operations along with the result, which might be useful for users willing to debug their instances of Observatorium.
+
+## Alternatives
+
+* Continuing with the existing process of using token-refresher and cURL and documenting that in detail.


### PR DESCRIPTION
This PR adds a proposal that talks about `obsctl` which is a dedicated CLI to interact with Observatorium instances.

cc: @onprem 