### PR TITLE
Rules API: Add docs

### DIFF
--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -8,6 +8,8 @@ The goal is to enable tenants to create, modify and access their own rules.
 
 ## Usage
 
+*Note: All requests to the endpoints below are **tenant scoped**; this means that each request requires a valid authentication token in the `Authorization` header.*
+
 ### Create rules
 
 ```
@@ -57,7 +59,7 @@ successfully updated rules file
 
 | Status Code | Description                                                                                           |
 |-------------|-------------------------------------------------------------------------------------------------------|
-| 200         | Successfully listed rules.                                                                            |
+| 200         | Successfully updated rules file                                                                       |
 | 401         | Error finding tenant/tenant ID.                                                                       |
 | 500         | A server side error happened while trying to create rules or while trying to write the response body. |
 

--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -110,3 +110,10 @@ The response format is in `application/yaml`.
 | 200         | Successfully listed rules.                               |
 | 401         | Error finding tenant/tenant ID.                          |
 | 500         | A server side error happened while trying to list rules. |
+
+## Difference between /api/v1/rules/raw and /api/v1/rules endpoints
+
+Note that the `/api/v1/rules/raw` endpoint differs from `/api/v1/rules` endpoint:
+
+* `/api/v1/rules/raw` supports `GET` and `PUT` requests, as described above. It refers only to the rules that were defined by the tenant that was authorized to use the endpoint.
+* `/api/v1/rules` supports `GET` requests and is the endpoint that is proxied by the Observatorium API to the read endpoint (in this case, Thanos Querier). It contains all rules from all tenants.

--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -2,8 +2,7 @@
 
 Observatorium is featured with a multi-tenant API that enables tenants to write and read Prometheus recording and alerting rules.
 
-The API is [defined](https://github.com/observatorium/api/blob/main/rules/spec.yaml) using the [OpenAPI](https://swagger.io/specification/)
-specification format.
+The API is [defined](https://github.com/observatorium/api/blob/main/rules/spec.yaml) using the [OpenAPI](https://swagger.io/specification/) specification format.
 
 The goal is to enable tenants to create, modify and access their own rules.
 
@@ -26,15 +25,13 @@ curl -X PUT --data-binary @alerting-rule.yaml --header "Content-Type: applicatio
 Where:
 
 * `rule.yaml` is a YAML file containing the desired rule definition. It can contain recording rules, alerting rules or both.
-  * _Note: For every `PUT` request, the content of the YAML file will be overwritten with the current content being sent._
+  * *Note: For every `PUT` request, the content of the YAML file will be overwritten with the current content being sent.*
 * `<observatorium-api-url>` is the URL where the Observatorium API is hosted.
 * `<tenant>` is the tenant name
 
-
 #### Example of a rule.yaml file
 
-The `rule.yaml` should be defined following the [Observatorium OpenAPI specification](https://github.com/observatorium/api/blob/main/rules/spec.yaml). The syntax is based on the Prometheus
-[recording](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) and [alerting](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) rules syntax.
+The `rule.yaml` should be defined following the [Observatorium OpenAPI specification](https://github.com/observatorium/api/blob/main/rules/spec.yaml). The syntax is based on the Prometheus [recording](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) and [alerting](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) rules syntax.
 
 Example of a `rule.yaml` file containing an alerting rule:
 
@@ -83,7 +80,6 @@ Where:
 * `<observatorium-api-url>` is the URL where Observatorium API is hosted.
 * `<tenant>` is the tenant name
 
-
 #### Example response
 
 ```yaml
@@ -104,10 +100,9 @@ groups:
 
 The response format is in `application/yaml`.
 
-_Note: In the current implementation from the Rules OpenAPI specification in Observatorium API, to better validate tenant rules, the label `tenant_id`
-was enforced in the read path:_
-* _In the `labels` field and_
-* _In the metrics that are present in the expression defined in the `expr` field._
+*Note: In the current implementation from the Rules OpenAPI specification in Observatorium API, to better validate tenant rules, the label `tenant_id` was enforced in the read path:*
+* *In the `labels` field and*
+* *In the metrics that are present in the expression defined in the `expr` field.*
 
 | Status Code | Description                                              |
 |-------------|----------------------------------------------------------|

--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -59,7 +59,7 @@ successfully updated rules file
 
 | Status Code | Description                                                                                           |
 |-------------|-------------------------------------------------------------------------------------------------------|
-| 200         | Successfully updated rules file                                                                       |
+| 200         | Successfully updated rules file.                                                                       |
 | 401         | Error finding tenant/tenant ID.                                                                       |
 | 500         | A server side error happened while trying to create rules or while trying to write the response body. |
 

--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -1,0 +1,84 @@
+# Rules API
+
+Observatorium is featured with a multi-tenant API that enables tenants to write and read Prometheus recording and alerting rules.
+
+The API is [defined](https://github.com/observatorium/api/blob/main/rules/spec.yaml) using the [OpenAPI](https://swagger.io/specification/)
+specification format.
+
+The goal is to enable tenants to create, modify and access their own rules.
+
+## Usage
+
+### List rules
+
+```bash
+GET /api/v1/rules/raw
+```
+
+List rules for a tenant.
+
+#### Example request
+
+```bash
+curl http://<observatorium-api-url>/api/metrics/v1/<tenant>/api/v1/rules/raw
+```
+
+Where:
+
+* `<observatorium-api-url>` is the URL where Observatorium API is hosted.
+* `<tenant>` is the tenant name
+
+
+#### Example response
+
+The response format is in `application/yaml`.
+
+| Status Code | Description                                              |
+|-------------|----------------------------------------------------------|
+| 200         | Successfully listed rules                                |
+| 401         | Error finding tenant/tenant ID                           |
+| 500         | A server side error happened while trying to list rules. |
+
+### Create rules
+
+```bash
+PUT /api/v1/rules/raw
+```
+
+Set rules for a tenant.
+
+#### Example request
+
+```bash
+curl -X PUT --data-binary @alerting-rule.yaml --header "Content-Type: application/yaml" http://<observatorium-api-url>/api/metrics/v1/<tenant>/api/v1/rules/raw
+```
+
+Where:
+
+* `rule.yaml` is a YAML file containing the desired rule definition.
+* `<observatorium-api-url>` is the URL where the Observatorium API is hosted.
+* `<tenant>` is the tenant name
+
+
+#### Example of a rule.yaml file
+
+The `rule.yaml` should be defined following the [Observatorium OpenAPI specification](https://github.com/observatorium/api/blob/main/rules/spec.yaml). The syntax is based on the Prometheus
+[recording](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) and [alerting](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+
+Example of a `rule.yaml` file containing an alerting rule:
+
+```yaml
+groups:
+  - name: test-alerting-rule
+    interval: 30s
+    rules:
+    - alert: HighRequestLatency
+      expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+      for: 10m
+      labels:
+        severity: page
+      annotations:
+        summary: High request latency
+```
+
+#### Example response

--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -59,7 +59,7 @@ successfully updated rules file
 
 | Status Code | Description                                                                                           |
 |-------------|-------------------------------------------------------------------------------------------------------|
-| 200         | Successfully updated rules file.                                                                       |
+| 200         | Successfully updated rules file.                                                                      |
 | 401         | Error finding tenant/tenant ID.                                                                       |
 | 500         | A server side error happened while trying to create rules or while trying to write the response body. |
 

--- a/docs/design/rules-api.md
+++ b/docs/design/rules-api.md
@@ -10,7 +10,7 @@ The goal is to enable tenants to create, modify and access their own rules.
 
 ### Create rules
 
-```bash
+```
 PUT /api/v1/rules/raw
 ```
 
@@ -24,8 +24,8 @@ curl -X PUT --data-binary @alerting-rule.yaml --header "Content-Type: applicatio
 
 Where:
 
-* `rule.yaml` is a YAML file containing the desired rule definition. It can contain recording rules, alerting rules or both.
-  * *Note: For every `PUT` request, the content of the YAML file will be overwritten with the current content being sent.*
+* `alerting-rule.yaml` is a YAML file containing the desired rule definition. It can contain recording rules, alerting rules or both.
+  * *Note: Each time a PUT request is made to the `/api/v1/rules/raw` endpoint, the rules contained in the request will overwrite all other rules for that tenant.*
 * `<observatorium-api-url>` is the URL where the Observatorium API is hosted.
 * `<tenant>` is the tenant name
 
@@ -51,7 +51,7 @@ groups:
 
 #### Example response
 
-```bash
+```
 successfully updated rules file
 ```
 
@@ -63,7 +63,7 @@ successfully updated rules file
 
 ### List rules
 
-```bash
+```
 GET /api/v1/rules/raw
 ```
 
@@ -101,6 +101,7 @@ groups:
 The response format is in `application/yaml`.
 
 *Note: In the current implementation from the Rules OpenAPI specification in Observatorium API, to better validate tenant rules, the label `tenant_id` was enforced in the read path:*
+
 * *In the `labels` field and*
 * *In the metrics that are present in the expression defined in the `expr` field.*
 


### PR DESCRIPTION
- Adds documentation about the recently implemented Rules API
- Would it be useful to add also an architecture diagram and mention `rules-objstore`? Or we would prefer to keep it simple and just mention how a tenant can interact with the API?