### PR TITLE
Add tracing jsonnet

### DIFF
--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -1,5 +1,6 @@
 local thanos = (import './thanos.libsonnet');
 local loki = (import './loki.libsonnet');
+local tracing = (import './tracing.libsonnet');
 local api = (import 'observatorium-api/observatorium-api.libsonnet');
 
 {
@@ -124,6 +125,12 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
       secretAccessKeyKey: 'aws_secret_access_key',
     },
   }),
+
+  tracing:: tracing({
+    local cfg = self,
+    namespace: 'observatorium',
+    commonLabels+:: obs.config.commonLabels,
+  }),
 } + {
   local obs = self,
 
@@ -142,5 +149,8 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     } + if std.objectHas(obs.loki, 'manifests') then {
       ['loki-' + name]: obs.loki.manifests[name]
       for name in std.objectFields(obs.loki.manifests)
+    } + if obs.tracing.config.enabled then {
+      ['tracing-' + name]: obs.tracing.manifests[name]
+      for name in std.objectFields(obs.tracing.manifests)
     } else {},
 }

--- a/configuration/components/tracing.libsonnet
+++ b/configuration/components/tracing.libsonnet
@@ -1,0 +1,104 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+
+  name: 'observatorium-xyz',
+  namespace: error 'must provide namespace',
+  tenants: [],
+  enabled: false,
+  otelcolVersion: '0.46.0',
+  // The core distribution does not contain routing processor, therefore using contrib distribution
+  // https://github.com/orgs/open-telemetry/packages?repo_name=opentelemetry-collector-releases
+  otelcolImage: 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib',
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'otelcol',
+    'app.kubernetes.io/part-of': 'observatorium',
+    'app.kubernetes.io/instance': defaults.name,
+  },
+};
+
+function(params) {
+  local tracing = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+
+  otelcolcfg:: {
+    receivers: {
+      otlp: {
+        protocols: {
+          grpc: {},
+        },
+      },
+    },
+    exporters: {
+      ['jaeger/' + tenant]: { endpoint: normalizedName(tracing.config.name + '-jaeger-' + tenant + '-collector:14250') }
+      for tenant in tracing.config.tenants
+    },
+    processors: {
+      routing: {
+        from_attribute: 'X-Tenant',
+        table: [
+          { value: tenant, exporters: ['jaeger/' + tenant] }
+          for tenant in tracing.config.tenants
+        ],
+      },
+    },
+    service: {
+      pipelines: {
+        traces: {
+          receivers: ['otlp'],
+          processors: ['routing'],
+          exporters: ['jaeger/' + tenant for tenant in tracing.config.tenants],
+        },
+      },
+    },
+  },
+
+  otelcolcr:: {
+    apiVersion: 'opentelemetry.io/v1alpha1',
+    kind: 'OpenTelemetryCollector',
+    metadata: {
+      name: normalizedName(tracing.config.name + '-otel'),
+      namespace: tracing.config.namespace,
+      labels: newCommonLabels('jaeger'),
+    },
+    spec: {
+      image: tracing.config.otelcolImage + ':' + tracing.config.otelcolVersion,
+      mode: 'deployment',
+      config: std.manifestYamlDoc(tracing.otelcolcfg, indent_array_in_object=false, quote_keys=false),
+    },
+  },
+
+  local normalizedName(id) =
+    std.strReplace(id, '_', '-'),
+
+  local newCommonLabels(component) =
+    tracing.config.commonLabels {
+      'app.kubernetes.io/component': normalizedName(component),
+    },
+
+  local newJaeger(component, config) =
+    local name = normalizedName(tracing.config.name + '-jaeger-' + component);
+    {
+      apiVersion: 'jaegertracing.io/v1',
+      kind: 'Jaeger',
+      metadata: {
+        name: name,
+        namespace: tracing.config.namespace,
+        labels: newCommonLabels(component),
+      },
+      spec: {
+        strategy: 'allinone',
+      },
+    },
+  manifests: {
+    otelcollector: tracing.otelcolcr,
+  } + {
+    [normalizedName('jaeger-' + tenant)]: newJaeger(tenant, tracing.config.components[tenant])
+    for tenant in tracing.config.tenants
+  },
+}

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -15,7 +15,14 @@ local minio = (import '../../components/minio.libsonnet')({
 
 local api = (import 'observatorium-api/observatorium-api.libsonnet');
 local obs = (import '../../components/observatorium.libsonnet');
+local tracing = (import '../../components/tracing.libsonnet');
 local dev = obs {
+  tracing: tracing(
+    obs.tracing.config {
+      tenants: [tenant.name],
+      enabled: true,
+    },
+  ),
   api: api(
     obs.api.config {
       rbac: {

--- a/configuration/examples/local/manifests/tracing-jaeger-test-oidc.yaml
+++ b/configuration/examples/local/manifests/tracing-jaeger-test-oidc.yaml
@@ -1,0 +1,12 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  labels:
+    app.kubernetes.io/component: test-oidc
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/part-of: observatorium
+  name: observatorium-xyz-jaeger-test-oidc
+  namespace: observatorium
+spec:
+  strategy: allinone

--- a/configuration/examples/local/manifests/tracing-otelcollector.yaml
+++ b/configuration/examples/local/manifests/tracing-otelcollector.yaml
@@ -1,0 +1,37 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  labels:
+    app.kubernetes.io/component: jaeger
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/part-of: observatorium
+  name: observatorium-xyz-otel
+  namespace: observatorium
+spec:
+  config: |-
+    exporters:
+      jaeger/test-oidc:
+        endpoint: "observatorium-xyz-jaeger-test-oidc-collector-headless:14250"
+    processors:
+      routing:
+        from_attribute: "X-Tenant"
+        table:
+        - exporters:
+          - "jaeger/test-oidc"
+          value: "test-oidc"
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+    service:
+      pipelines:
+        traces:
+          exporters:
+          - "jaeger/test-oidc"
+          processors:
+          - "routing"
+          receivers:
+          - "otlp"
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.46.0
+  mode: deployment


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Depends on https://github.com/observatorium/api/pull/199 that will allow us to enable tracing ingestion in the Observatorim API service and forward traces to collector. 