### PR TITLE
loki: Bump v2.2.0 to v2.4.2 and fix config

### DIFF
--- a/configuration/components/loki.libsonnet
+++ b/configuration/components/loki.libsonnet
@@ -11,8 +11,7 @@ local defaults = {
   imagePullPolicy: 'IfNotPresent',
   replicas: error 'must provide replicas',
   objectStorageConfig: error 'must provide object storage config',
-  queryConcurrency: 32,
-  queryParallelism: 32,  // Defaults to queryConcurrency because single query-frontend replica
+  queryConcurrency: error 'must provide max concurrent setting for querier config',
   ports: {
     gossip: 7946,
   },
@@ -171,7 +170,7 @@ local defaults = {
       grpc_client_config: {
         max_send_msg_size: grpcServerMaxMsgSize,
       },
-      parallelism: defaults.queryParallelism,
+      match_max_concurrent: true,
     },
     ingester: {
       chunk_block_size: 262144,
@@ -228,6 +227,7 @@ local defaults = {
         timeout: '3m',
         max_look_back_period: '5m',
       },
+      max_concurrent: defaults.queryConcurrency,
     },
     query_range: {
       align_queries_with_step: true,
@@ -324,7 +324,6 @@ function(params) {
   config:: defaults + params,
   // Safety checks for combined config of defaults and params.
   assert std.isNumber(loki.config.queryConcurrency),
-  assert std.isNumber(loki.config.queryParallelism),
   assert std.isNumber(loki.config.replicationFactor),
   assert std.isObject(loki.config.replicas) : 'replicas has to be an object',
   assert std.isObject(loki.config.resources) : 'replicas has to be an object',

--- a/configuration/components/loki.libsonnet
+++ b/configuration/components/loki.libsonnet
@@ -23,6 +23,9 @@ local defaults = {
   volumeClaimTemplates: {},
   memberlist: {},
   etcd: {},
+  wal: {
+    replayMemoryCeiling: error 'must provide replay memory ceiling',
+  },
 
   indexQueryCache: '',
   storeChunkCache: '',
@@ -191,6 +194,11 @@ local defaults = {
         },
       },
       max_transfer_retries: 0,
+      wal: {
+        enabled: true,
+        dir: '/data/loki/wal',
+        replay_memory_ceiling: defaults.wal.replayMemoryCeiling,
+      },
     },
     ingester_client: {
       grpc_client_config: {

--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -99,6 +99,7 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     image: 'docker.io/grafana/loki:' + cfg.version,
     imagePullPolicy: 'IfNotPresent',
     replicationFactor: 1,
+    queryConcurrency: 2,
     replicas: {
       compactor: 1,
       distributor: 1,

--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -95,7 +95,7 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'],
     namespace: obs.config.namespace,
     commonLabels+:: obs.config.commonLabels,
-    version: '2.2.0',
+    version: '2.4.2',
     image: 'docker.io/grafana/loki:' + cfg.version,
     imagePullPolicy: 'IfNotPresent',
     replicationFactor: 1,
@@ -108,6 +108,9 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     },
     memberlist: {
       ringName: 'gossip-ring',
+    },
+    wal: {
+      replayMemoryCeiling: '100MB',
     },
     volumeClaimTemplate: {
       spec: {

--- a/configuration/examples/base/manifests/loki-compactor-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-compactor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-compactor-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-compactor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-compactor-statefulset.yaml
+++ b/configuration/examples/base/manifests/loki-compactor-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/base/manifests/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/loki-config-map.yaml
@@ -37,6 +37,10 @@ data:
           "kvstore":
             "store": "memberlist"
       "max_transfer_retries": 0
+      "wal":
+        "dir": "/data/loki/wal"
+        "enabled": true
+        "replay_memory_ceiling": "100MB"
     "ingester_client":
       "grpc_client_config":
         "max_recv_msg_size": 67108864
@@ -105,6 +109,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/configuration/examples/base/manifests/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/loki-config-map.yaml
@@ -19,7 +19,7 @@ data:
       "frontend_address": "observatorium-xyz-loki-query-frontend-grpc.observatorium.svc.cluster.local:9095"
       "grpc_client_config":
         "max_send_msg_size": 104857600
-      "parallelism": 32
+      "match_max_concurrent": true
     "ingester":
       "chunk_block_size": 262144
       "chunk_encoding": "snappy"
@@ -70,6 +70,7 @@ data:
         "max_look_back_period": "5m"
         "timeout": "3m"
       "extra_query_delay": "0s"
+      "max_concurrent": 2
       "query_ingesters_within": "2h"
       "query_timeout": "1h"
       "tail_max_duration": "1h"

--- a/configuration/examples/base/manifests/loki-distributor-deployment.yaml
+++ b/configuration/examples/base/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/base/manifests/loki-distributor-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-distributor-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-gossip-ring.yaml
+++ b/configuration/examples/base/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-ingester-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-ingester-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-ingester-statefulset.yaml
+++ b/configuration/examples/base/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/base/manifests/loki-querier-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-querier-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-querier-statefulset.yaml
+++ b/configuration/examples/base/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/base/manifests/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/base/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -40,7 +40,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/base/manifests/loki-query-frontend-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/base/manifests/loki-query-frontend-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-compactor-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-compactor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-compactor-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-compactor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-compactor-statefulset.yaml
+++ b/configuration/examples/dev/manifests/loki-compactor-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/dev/manifests/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/loki-config-map.yaml
@@ -37,6 +37,10 @@ data:
           "kvstore":
             "store": "memberlist"
       "max_transfer_retries": 0
+      "wal":
+        "dir": "/data/loki/wal"
+        "enabled": true
+        "replay_memory_ceiling": "100MB"
     "ingester_client":
       "grpc_client_config":
         "max_recv_msg_size": 67108864
@@ -105,6 +109,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/configuration/examples/dev/manifests/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/loki-config-map.yaml
@@ -19,7 +19,7 @@ data:
       "frontend_address": "observatorium-xyz-loki-query-frontend-grpc.observatorium.svc.cluster.local:9095"
       "grpc_client_config":
         "max_send_msg_size": 104857600
-      "parallelism": 32
+      "match_max_concurrent": true
     "ingester":
       "chunk_block_size": 262144
       "chunk_encoding": "snappy"
@@ -70,6 +70,7 @@ data:
         "max_look_back_period": "5m"
         "timeout": "3m"
       "extra_query_delay": "0s"
+      "max_concurrent": 2
       "query_ingesters_within": "2h"
       "query_timeout": "1h"
       "tail_max_duration": "1h"

--- a/configuration/examples/dev/manifests/loki-distributor-deployment.yaml
+++ b/configuration/examples/dev/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/dev/manifests/loki-distributor-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-distributor-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-gossip-ring.yaml
+++ b/configuration/examples/dev/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-ingester-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-ingester-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-ingester-statefulset.yaml
+++ b/configuration/examples/dev/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/dev/manifests/loki-querier-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-querier-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-querier-statefulset.yaml
+++ b/configuration/examples/dev/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/dev/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -40,7 +40,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/dev/manifests/loki-query-frontend-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/dev/manifests/loki-query-frontend-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-compactor-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-compactor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-compactor-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-compactor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-compactor-statefulset.yaml
+++ b/configuration/examples/local/manifests/loki-compactor-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/local/manifests/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/loki-config-map.yaml
@@ -37,6 +37,10 @@ data:
           "kvstore":
             "store": "memberlist"
       "max_transfer_retries": 0
+      "wal":
+        "dir": "/data/loki/wal"
+        "enabled": true
+        "replay_memory_ceiling": "100MB"
     "ingester_client":
       "grpc_client_config":
         "max_recv_msg_size": 67108864
@@ -105,6 +109,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/configuration/examples/local/manifests/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/loki-config-map.yaml
@@ -19,7 +19,7 @@ data:
       "frontend_address": "observatorium-xyz-loki-query-frontend-grpc.observatorium.svc.cluster.local:9095"
       "grpc_client_config":
         "max_send_msg_size": 104857600
-      "parallelism": 32
+      "match_max_concurrent": true
     "ingester":
       "chunk_block_size": 262144
       "chunk_encoding": "snappy"
@@ -70,6 +70,7 @@ data:
         "max_look_back_period": "5m"
         "timeout": "3m"
       "extra_query_delay": "0s"
+      "max_concurrent": 2
       "query_ingesters_within": "2h"
       "query_timeout": "1h"
       "tail_max_duration": "1h"

--- a/configuration/examples/local/manifests/loki-distributor-deployment.yaml
+++ b/configuration/examples/local/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/local/manifests/loki-distributor-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-distributor-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-gossip-ring.yaml
+++ b/configuration/examples/local/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-ingester-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-ingester-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-ingester-statefulset.yaml
+++ b/configuration/examples/local/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/local/manifests/loki-querier-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-querier-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-querier-statefulset.yaml
+++ b/configuration/examples/local/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/local/manifests/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/local/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -40,7 +40,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.2.0
+        image: docker.io/grafana/loki:2.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/configuration/examples/local/manifests/loki-query-frontend-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/configuration/examples/local/manifests/loki-query-frontend-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.4.2
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:


### PR DESCRIPTION
This PR bumps Loki to 2.4.2 and introduces:
1. The Work-Ahead-Log (WAL) feature. Enabling the WAL will ensure that rolling restarts of ingesters don't need in critical situations manual intervention anymore (i.e. dropping the last ingesters manually from the distributor memberlist UI).
2. Replaces the `frontend_worker.parallelism` with the `querier.max_concurrent` setting. Former required manual tuning on every querier scale out, while latter is dynamically tuned by queriers on scale out.