### PR TITLE
loki: Add query scheduler and index gateway components

### DIFF
--- a/configuration/components/loki.libsonnet
+++ b/configuration/components/loki.libsonnet
@@ -299,9 +299,11 @@ local defaults = {
         },
       } else {
         results_cache: {
-          enable_fifocache: true,
-          fifocache: {
-            max_size_bytes: '500MB',
+          cache: {
+            enable_fifocache: true,
+            fifocache: {
+              max_size_bytes: '500MB',
+            },
           },
         },
       }

--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -104,8 +104,10 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
       compactor: 1,
       distributor: 1,
       ingester: 1,
+      index_gateway: 1,
       querier: 1,
       query_frontend: 1,
+      query_scheduler: 1,
     },
     memberlist: {
       ringName: 'gossip-ring',

--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -99,7 +99,9 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     image: 'docker.io/grafana/loki:' + cfg.version,
     imagePullPolicy: 'IfNotPresent',
     replicationFactor: 1,
-    queryConcurrency: 2,
+    query+: {
+      concurrency: 2,
+    },
     replicas: {
       compactor: 1,
       distributor: 1,

--- a/configuration/examples/base/manifests/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/loki-config-map.yaml
@@ -96,9 +96,10 @@ data:
       "max_retries": 5
       "parallelise_shardable_queries": true
       "results_cache":
-        "enable_fifocache": true
-        "fifocache":
-          "max_size_bytes": "500MB"
+        "cache":
+          "enable_fifocache": true
+          "fifocache":
+            "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
     "query_scheduler":
       "max_outstanding_per_tenant": 100

--- a/configuration/examples/base/manifests/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/loki-config-map.yaml
@@ -3,6 +3,10 @@ data:
   config.yaml: |-
     "auth_enabled": true
     "chunk_store_config":
+      "chunk_cache_config":
+        "enable_fifocache": true
+        "fifocache":
+          "max_size_bytes": "500MB"
       "max_look_back_period": "0s"
     "compactor":
       "compaction_interval": "2h"
@@ -14,18 +18,19 @@ data:
           "store": "memberlist"
     "frontend":
       "compress_responses": true
-      "max_outstanding_per_tenant": 200
+      "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
+      "tail_proxy_url": "observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100"
     "frontend_worker":
-      "frontend_address": "observatorium-xyz-loki-query-frontend-grpc.observatorium.svc.cluster.local:9095"
       "grpc_client_config":
         "max_send_msg_size": 104857600
       "match_max_concurrent": true
+      "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
     "ingester":
       "chunk_block_size": 262144
       "chunk_encoding": "snappy"
-      "chunk_idle_period": "2h"
-      "chunk_retain_period": "1m"
-      "chunk_target_size": 1572864
+      "chunk_idle_period": "1h"
+      "chunk_retain_period": "5m"
+      "chunk_target_size": 2097152
       "lifecycler":
         "heartbeat_period": "5s"
         "interface_names":
@@ -46,15 +51,26 @@ data:
         "max_recv_msg_size": 67108864
       "remote_timeout": "1s"
     "limits_config":
+      "cardinality_limit": 100000
+      "creation_grace_period": "10m"
       "enforce_metric_name": false
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
       "max_cache_freshness_per_query": "10m"
+      "max_chunks_per_query": 2000000
+      "max_entries_limit_per_query": 5000
       "max_global_streams_per_user": 10000
-      "max_query_length": "12000h"
+      "max_label_name_length": 1024
+      "max_label_names_per_series": 30
+      "max_label_value_length": 2048
+      "max_line_size": 256000
+      "max_query_length": "721h"
       "max_query_parallelism": 32
+      "max_query_series": 500
       "max_streams_per_user": 0
+      "per_stream_rate_limit": "3MB"
+      "per_stream_rate_limit_burst": "15MB"
       "reject_old_samples": true
       "reject_old_samples_max_age": "24h"
     "memberlist":
@@ -67,18 +83,25 @@ data:
       "min_join_backoff": "1s"
     "querier":
       "engine":
-        "max_look_back_period": "5m"
+        "max_look_back_period": "30s"
         "timeout": "3m"
       "extra_query_delay": "0s"
       "max_concurrent": 2
-      "query_ingesters_within": "2h"
+      "query_ingesters_within": "3h"
       "query_timeout": "1h"
       "tail_max_duration": "1h"
     "query_range":
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
+      "parallelise_shardable_queries": true
+      "results_cache":
+        "enable_fifocache": true
+        "fifocache":
+          "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
+    "query_scheduler":
+      "max_outstanding_per_tenant": 100
     "schema_config":
       "configs":
       - "from": "2020-10-01"
@@ -93,14 +116,19 @@ data:
       "grpc_server_max_concurrent_streams": 1000
       "grpc_server_max_recv_msg_size": 104857600
       "grpc_server_max_send_msg_size": 104857600
+      "grpc_server_min_time_between_pings": "10s"
+      "grpc_server_ping_without_stream_allowed": true
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
+      "log_level": "error"
     "storage_config":
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
         "cache_ttl": "24h"
+        "index_gateway_client":
+          "server_address": "observatorium-xyz-loki-index-gateway-grpc.observatorium.svc.cluster.local:9095"
         "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'

--- a/configuration/examples/base/manifests/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/loki-config-map.yaml
@@ -66,7 +66,7 @@ data:
       "max_label_value_length": 2048
       "max_line_size": 256000
       "max_query_length": "721h"
-      "max_query_parallelism": 32
+      "max_query_parallelism": 16
       "max_query_series": 500
       "max_streams_per_user": 0
       "per_stream_rate_limit": "3MB"
@@ -94,7 +94,7 @@ data:
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
-      "parallelise_shardable_queries": true
+      "parallelise_shardable_queries": false
       "results_cache":
         "cache":
           "enable_fifocache": true
@@ -102,7 +102,7 @@ data:
             "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
     "query_scheduler":
-      "max_outstanding_per_tenant": 100
+      "max_outstanding_requests_per_tenant": 256
     "schema_config":
       "configs":
       - "from": "2020-10-01"

--- a/configuration/examples/base/manifests/loki-index-gateway-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-index-gateway-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/base/manifests/loki-index-gateway-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-index-gateway-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/base/manifests/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/base/manifests/loki-index-gateway-statefulset.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: index-gateway
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+  serviceName: observatorium-xyz-loki-index-gateway-grpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: index-gateway
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+    spec:
+      containers:
+      - args:
+        - -target=index-gateway
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        - -distributor.replication-factor=1
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /metrics
+            port: 3100
+            scheme: HTTP
+          periodSeconds: 30
+        name: observatorium-xyz-loki-index-gateway
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+      name: storage
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Mi

--- a/configuration/examples/base/manifests/loki-querier-deployment.yaml
+++ b/configuration/examples/base/manifests/loki-querier-deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-querier
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+      loki.grafana.com/gossip: "true"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
+    spec:
+      containers:
+      - args:
+        - -target=querier
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        - -distributor.replication-factor=1
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /metrics
+            port: 3100
+            scheme: HTTP
+          periodSeconds: 30
+        name: observatorium-xyz-loki-querier
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+      - emptyDir: {}
+        name: storage

--- a/configuration/examples/base/manifests/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/base/manifests/loki-query-scheduler-deployment.yaml
@@ -1,36 +1,33 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: querier
+    app.kubernetes.io/component: query-scheduler
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
     app.kubernetes.io/version: 2.4.2
-  name: observatorium-xyz-loki-querier
+  name: observatorium-xyz-loki-query-scheduler
   namespace: observatorium
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
+      app.kubernetes.io/component: query-scheduler
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
-  serviceName: observatorium-xyz-loki-querier-grpc
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: querier
+        app.kubernetes.io/component: query-scheduler
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
-        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
-        - -target=querier
+        - -target=query-scheduler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
@@ -52,14 +49,12 @@ spec:
             port: 3100
             scheme: HTTP
           periodSeconds: 30
-        name: observatorium-xyz-loki-querier
+        name: observatorium-xyz-loki-query-scheduler
         ports:
         - containerPort: 3100
           name: metrics
         - containerPort: 9095
           name: grpc
-        - containerPort: 7946
-          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
@@ -85,16 +80,5 @@ spec:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-  volumeClaimTemplates:
-  - metadata:
-      labels:
-        app.kubernetes.io/instance: observatorium-xyz
-        app.kubernetes.io/name: loki
-        app.kubernetes.io/part-of: observatorium
-      name: storage
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 250Mi
+      - emptyDir: {}
+        name: storage

--- a/configuration/examples/base/manifests/loki-query-scheduler-grpc-service.yaml
+++ b/configuration/examples/base/manifests/loki-query-scheduler-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-query-scheduler-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/base/manifests/loki-query-scheduler-http-service.yaml
+++ b/configuration/examples/base/manifests/loki-query-scheduler-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-query-scheduler-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/dev/main.jsonnet
+++ b/configuration/examples/dev/main.jsonnet
@@ -39,8 +39,22 @@ local minio = (import '../../components/minio.libsonnet')({
 });
 
 local api = (import 'observatorium-api/observatorium-api.libsonnet');
+local loki = (import '../../components/loki.libsonnet');
 local obs = (import '../../components/observatorium.libsonnet');
 local dev = obs {
+  loki: loki(
+    obs.loki.config {
+      config+: {
+        querier+: {
+          engine+: {
+            max_look_back_period: '5m',
+          },
+        },
+      },
+    },
+  ),
+
+
   api: api(
     obs.api.config {
       rbac: {

--- a/configuration/examples/dev/manifests/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/loki-config-map.yaml
@@ -96,9 +96,10 @@ data:
       "max_retries": 5
       "parallelise_shardable_queries": true
       "results_cache":
-        "enable_fifocache": true
-        "fifocache":
-          "max_size_bytes": "500MB"
+        "cache":
+          "enable_fifocache": true
+          "fifocache":
+            "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
     "query_scheduler":
       "max_outstanding_per_tenant": 100

--- a/configuration/examples/dev/manifests/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/loki-config-map.yaml
@@ -3,6 +3,10 @@ data:
   config.yaml: |-
     "auth_enabled": true
     "chunk_store_config":
+      "chunk_cache_config":
+        "enable_fifocache": true
+        "fifocache":
+          "max_size_bytes": "500MB"
       "max_look_back_period": "0s"
     "compactor":
       "compaction_interval": "2h"
@@ -14,18 +18,19 @@ data:
           "store": "memberlist"
     "frontend":
       "compress_responses": true
-      "max_outstanding_per_tenant": 200
+      "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
+      "tail_proxy_url": "observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100"
     "frontend_worker":
-      "frontend_address": "observatorium-xyz-loki-query-frontend-grpc.observatorium.svc.cluster.local:9095"
       "grpc_client_config":
         "max_send_msg_size": 104857600
       "match_max_concurrent": true
+      "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
     "ingester":
       "chunk_block_size": 262144
       "chunk_encoding": "snappy"
-      "chunk_idle_period": "2h"
-      "chunk_retain_period": "1m"
-      "chunk_target_size": 1572864
+      "chunk_idle_period": "1h"
+      "chunk_retain_period": "5m"
+      "chunk_target_size": 2097152
       "lifecycler":
         "heartbeat_period": "5s"
         "interface_names":
@@ -46,15 +51,26 @@ data:
         "max_recv_msg_size": 67108864
       "remote_timeout": "1s"
     "limits_config":
+      "cardinality_limit": 100000
+      "creation_grace_period": "10m"
       "enforce_metric_name": false
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
       "max_cache_freshness_per_query": "10m"
+      "max_chunks_per_query": 2000000
+      "max_entries_limit_per_query": 5000
       "max_global_streams_per_user": 10000
-      "max_query_length": "12000h"
+      "max_label_name_length": 1024
+      "max_label_names_per_series": 30
+      "max_label_value_length": 2048
+      "max_line_size": 256000
+      "max_query_length": "721h"
       "max_query_parallelism": 32
+      "max_query_series": 500
       "max_streams_per_user": 0
+      "per_stream_rate_limit": "3MB"
+      "per_stream_rate_limit_burst": "15MB"
       "reject_old_samples": true
       "reject_old_samples_max_age": "24h"
     "memberlist":
@@ -67,18 +83,25 @@ data:
       "min_join_backoff": "1s"
     "querier":
       "engine":
-        "max_look_back_period": "5m"
+        "max_look_back_period": "30s"
         "timeout": "3m"
       "extra_query_delay": "0s"
       "max_concurrent": 2
-      "query_ingesters_within": "2h"
+      "query_ingesters_within": "3h"
       "query_timeout": "1h"
       "tail_max_duration": "1h"
     "query_range":
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
+      "parallelise_shardable_queries": true
+      "results_cache":
+        "enable_fifocache": true
+        "fifocache":
+          "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
+    "query_scheduler":
+      "max_outstanding_per_tenant": 100
     "schema_config":
       "configs":
       - "from": "2020-10-01"
@@ -93,14 +116,19 @@ data:
       "grpc_server_max_concurrent_streams": 1000
       "grpc_server_max_recv_msg_size": 104857600
       "grpc_server_max_send_msg_size": 104857600
+      "grpc_server_min_time_between_pings": "10s"
+      "grpc_server_ping_without_stream_allowed": true
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
+      "log_level": "error"
     "storage_config":
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
         "cache_ttl": "24h"
+        "index_gateway_client":
+          "server_address": "observatorium-xyz-loki-index-gateway-grpc.observatorium.svc.cluster.local:9095"
         "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'

--- a/configuration/examples/dev/manifests/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/loki-config-map.yaml
@@ -83,7 +83,7 @@ data:
       "min_join_backoff": "1s"
     "querier":
       "engine":
-        "max_look_back_period": "30s"
+        "max_look_back_period": "5m"
         "timeout": "3m"
       "extra_query_delay": "0s"
       "max_concurrent": 2

--- a/configuration/examples/dev/manifests/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/loki-config-map.yaml
@@ -66,7 +66,7 @@ data:
       "max_label_value_length": 2048
       "max_line_size": 256000
       "max_query_length": "721h"
-      "max_query_parallelism": 32
+      "max_query_parallelism": 16
       "max_query_series": 500
       "max_streams_per_user": 0
       "per_stream_rate_limit": "3MB"
@@ -94,7 +94,7 @@ data:
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
-      "parallelise_shardable_queries": true
+      "parallelise_shardable_queries": false
       "results_cache":
         "cache":
           "enable_fifocache": true
@@ -102,7 +102,7 @@ data:
             "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
     "query_scheduler":
-      "max_outstanding_per_tenant": 100
+      "max_outstanding_requests_per_tenant": 256
     "schema_config":
       "configs":
       - "from": "2020-10-01"

--- a/configuration/examples/dev/manifests/loki-index-gateway-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-index-gateway-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/dev/manifests/loki-index-gateway-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-index-gateway-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/dev/manifests/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/dev/manifests/loki-index-gateway-statefulset.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: index-gateway
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+  serviceName: observatorium-xyz-loki-index-gateway-grpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: index-gateway
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+    spec:
+      containers:
+      - args:
+        - -target=index-gateway
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        - -distributor.replication-factor=1
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /metrics
+            port: 3100
+            scheme: HTTP
+          periodSeconds: 30
+        name: observatorium-xyz-loki-index-gateway
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+      name: storage
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Mi

--- a/configuration/examples/dev/manifests/loki-querier-deployment.yaml
+++ b/configuration/examples/dev/manifests/loki-querier-deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-querier
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+      loki.grafana.com/gossip: "true"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
+    spec:
+      containers:
+      - args:
+        - -target=querier
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        - -distributor.replication-factor=1
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /metrics
+            port: 3100
+            scheme: HTTP
+          periodSeconds: 30
+        name: observatorium-xyz-loki-querier
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+      - emptyDir: {}
+        name: storage

--- a/configuration/examples/dev/manifests/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/dev/manifests/loki-query-scheduler-deployment.yaml
@@ -1,36 +1,33 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: querier
+    app.kubernetes.io/component: query-scheduler
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
     app.kubernetes.io/version: 2.4.2
-  name: observatorium-xyz-loki-querier
+  name: observatorium-xyz-loki-query-scheduler
   namespace: observatorium
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
+      app.kubernetes.io/component: query-scheduler
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
-  serviceName: observatorium-xyz-loki-querier-grpc
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: querier
+        app.kubernetes.io/component: query-scheduler
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
-        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
-        - -target=querier
+        - -target=query-scheduler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
@@ -52,14 +49,12 @@ spec:
             port: 3100
             scheme: HTTP
           periodSeconds: 30
-        name: observatorium-xyz-loki-querier
+        name: observatorium-xyz-loki-query-scheduler
         ports:
         - containerPort: 3100
           name: metrics
         - containerPort: 9095
           name: grpc
-        - containerPort: 7946
-          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
@@ -85,16 +80,5 @@ spec:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-  volumeClaimTemplates:
-  - metadata:
-      labels:
-        app.kubernetes.io/instance: observatorium-xyz
-        app.kubernetes.io/name: loki
-        app.kubernetes.io/part-of: observatorium
-      name: storage
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 250Mi
+      - emptyDir: {}
+        name: storage

--- a/configuration/examples/dev/manifests/loki-query-scheduler-grpc-service.yaml
+++ b/configuration/examples/dev/manifests/loki-query-scheduler-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-query-scheduler-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/dev/manifests/loki-query-scheduler-http-service.yaml
+++ b/configuration/examples/dev/manifests/loki-query-scheduler-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-query-scheduler-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/local/manifests/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/loki-config-map.yaml
@@ -96,9 +96,10 @@ data:
       "max_retries": 5
       "parallelise_shardable_queries": true
       "results_cache":
-        "enable_fifocache": true
-        "fifocache":
-          "max_size_bytes": "500MB"
+        "cache":
+          "enable_fifocache": true
+          "fifocache":
+            "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
     "query_scheduler":
       "max_outstanding_per_tenant": 100

--- a/configuration/examples/local/manifests/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/loki-config-map.yaml
@@ -3,6 +3,10 @@ data:
   config.yaml: |-
     "auth_enabled": true
     "chunk_store_config":
+      "chunk_cache_config":
+        "enable_fifocache": true
+        "fifocache":
+          "max_size_bytes": "500MB"
       "max_look_back_period": "0s"
     "compactor":
       "compaction_interval": "2h"
@@ -14,18 +18,19 @@ data:
           "store": "memberlist"
     "frontend":
       "compress_responses": true
-      "max_outstanding_per_tenant": 200
+      "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
+      "tail_proxy_url": "observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100"
     "frontend_worker":
-      "frontend_address": "observatorium-xyz-loki-query-frontend-grpc.observatorium.svc.cluster.local:9095"
       "grpc_client_config":
         "max_send_msg_size": 104857600
       "match_max_concurrent": true
+      "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
     "ingester":
       "chunk_block_size": 262144
       "chunk_encoding": "snappy"
-      "chunk_idle_period": "2h"
-      "chunk_retain_period": "1m"
-      "chunk_target_size": 1572864
+      "chunk_idle_period": "1h"
+      "chunk_retain_period": "5m"
+      "chunk_target_size": 2097152
       "lifecycler":
         "heartbeat_period": "5s"
         "interface_names":
@@ -46,15 +51,26 @@ data:
         "max_recv_msg_size": 67108864
       "remote_timeout": "1s"
     "limits_config":
+      "cardinality_limit": 100000
+      "creation_grace_period": "10m"
       "enforce_metric_name": false
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
       "max_cache_freshness_per_query": "10m"
+      "max_chunks_per_query": 2000000
+      "max_entries_limit_per_query": 5000
       "max_global_streams_per_user": 10000
-      "max_query_length": "12000h"
+      "max_label_name_length": 1024
+      "max_label_names_per_series": 30
+      "max_label_value_length": 2048
+      "max_line_size": 256000
+      "max_query_length": "721h"
       "max_query_parallelism": 32
+      "max_query_series": 500
       "max_streams_per_user": 0
+      "per_stream_rate_limit": "3MB"
+      "per_stream_rate_limit_burst": "15MB"
       "reject_old_samples": true
       "reject_old_samples_max_age": "24h"
     "memberlist":
@@ -67,18 +83,25 @@ data:
       "min_join_backoff": "1s"
     "querier":
       "engine":
-        "max_look_back_period": "5m"
+        "max_look_back_period": "30s"
         "timeout": "3m"
       "extra_query_delay": "0s"
       "max_concurrent": 2
-      "query_ingesters_within": "2h"
+      "query_ingesters_within": "3h"
       "query_timeout": "1h"
       "tail_max_duration": "1h"
     "query_range":
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
+      "parallelise_shardable_queries": true
+      "results_cache":
+        "enable_fifocache": true
+        "fifocache":
+          "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
+    "query_scheduler":
+      "max_outstanding_per_tenant": 100
     "schema_config":
       "configs":
       - "from": "2020-10-01"
@@ -93,14 +116,19 @@ data:
       "grpc_server_max_concurrent_streams": 1000
       "grpc_server_max_recv_msg_size": 104857600
       "grpc_server_max_send_msg_size": 104857600
+      "grpc_server_min_time_between_pings": "10s"
+      "grpc_server_ping_without_stream_allowed": true
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
+      "log_level": "error"
     "storage_config":
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
         "cache_ttl": "24h"
+        "index_gateway_client":
+          "server_address": "observatorium-xyz-loki-index-gateway-grpc.observatorium.svc.cluster.local:9095"
         "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'

--- a/configuration/examples/local/manifests/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/loki-config-map.yaml
@@ -66,7 +66,7 @@ data:
       "max_label_value_length": 2048
       "max_line_size": 256000
       "max_query_length": "721h"
-      "max_query_parallelism": 32
+      "max_query_parallelism": 16
       "max_query_series": 500
       "max_streams_per_user": 0
       "per_stream_rate_limit": "3MB"
@@ -94,7 +94,7 @@ data:
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
-      "parallelise_shardable_queries": true
+      "parallelise_shardable_queries": false
       "results_cache":
         "cache":
           "enable_fifocache": true
@@ -102,7 +102,7 @@ data:
             "max_size_bytes": "500MB"
       "split_queries_by_interval": "30m"
     "query_scheduler":
-      "max_outstanding_per_tenant": 100
+      "max_outstanding_requests_per_tenant": 256
     "schema_config":
       "configs":
       - "from": "2020-10-01"

--- a/configuration/examples/local/manifests/loki-index-gateway-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-index-gateway-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/local/manifests/loki-index-gateway-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-index-gateway-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/local/manifests/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/local/manifests/loki-index-gateway-statefulset.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-index-gateway
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: index-gateway
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+  serviceName: observatorium-xyz-loki-index-gateway-grpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: index-gateway
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+    spec:
+      containers:
+      - args:
+        - -target=index-gateway
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        - -distributor.replication-factor=1
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /metrics
+            port: 3100
+            scheme: HTTP
+          periodSeconds: 30
+        name: observatorium-xyz-loki-index-gateway
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+      name: storage
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Mi

--- a/configuration/examples/local/manifests/loki-querier-deployment.yaml
+++ b/configuration/examples/local/manifests/loki-querier-deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-querier
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+      loki.grafana.com/gossip: "true"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
+    spec:
+      containers:
+      - args:
+        - -target=querier
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        - -distributor.replication-factor=1
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /metrics
+            port: 3100
+            scheme: HTTP
+          periodSeconds: 30
+        name: observatorium-xyz-loki-querier
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+      - emptyDir: {}
+        name: storage

--- a/configuration/examples/local/manifests/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/local/manifests/loki-query-scheduler-deployment.yaml
@@ -1,36 +1,33 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: querier
+    app.kubernetes.io/component: query-scheduler
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
     app.kubernetes.io/version: 2.4.2
-  name: observatorium-xyz-loki-querier
+  name: observatorium-xyz-loki-query-scheduler
   namespace: observatorium
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
+      app.kubernetes.io/component: query-scheduler
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
-  serviceName: observatorium-xyz-loki-querier-grpc
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: querier
+        app.kubernetes.io/component: query-scheduler
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
-        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
-        - -target=querier
+        - -target=query-scheduler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
@@ -52,14 +49,12 @@ spec:
             port: 3100
             scheme: HTTP
           periodSeconds: 30
-        name: observatorium-xyz-loki-querier
+        name: observatorium-xyz-loki-query-scheduler
         ports:
         - containerPort: 3100
           name: metrics
         - containerPort: 9095
           name: grpc
-        - containerPort: 7946
-          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
@@ -85,16 +80,5 @@ spec:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-  volumeClaimTemplates:
-  - metadata:
-      labels:
-        app.kubernetes.io/instance: observatorium-xyz
-        app.kubernetes.io/name: loki
-        app.kubernetes.io/part-of: observatorium
-      name: storage
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 250Mi
+      - emptyDir: {}
+        name: storage

--- a/configuration/examples/local/manifests/loki-query-scheduler-grpc-service.yaml
+++ b/configuration/examples/local/manifests/loki-query-scheduler-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-query-scheduler-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/local/manifests/loki-query-scheduler-http-service.yaml
+++ b/configuration/examples/local/manifests/loki-query-scheduler-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.4.2
+  name: observatorium-xyz-loki-query-scheduler-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/configuration/examples/local/quickstart.sh
+++ b/configuration/examples/local/quickstart.sh
@@ -140,7 +140,7 @@ deploy() {
   echo "-------------------------------------------"
   mkdir -p tmp/grafana
   (docker run -p 3000:3000 --user $(id -u) --volume "$PWD/tmp/grafana:/var/lib/grafana" grafana/grafana:7.3.7 &> /dev/null) &
-  echo "Open http://localhost:3000 in your browser. Add Prometheus datasource with endpoint http://172.17.0.1:8080/api/metrics/v1/test-oidc."
+  echo -e "Open http://localhost:3000 in your browser. \nAdd Prometheus datasource with endpoint http://172.17.0.1:8080/api/metrics/v1/test-oidc. \nAdd Loki datasource with endpoint http://172.17.0.1:8080/api/logs/v1/test-oidc."
 }
 
 case $1 in

--- a/configuration/tests/e2e.sh
+++ b/configuration/tests/e2e.sh
@@ -9,7 +9,7 @@ OS_TYPE=$(echo `uname -s` | tr '[:upper:]' '[:lower:]')
 
 kind() {
     curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/$OS_TYPE/amd64/kubectl
-    curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-$OS_TYPE-amd64
+    curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-$OS_TYPE-amd64
     chmod +x kind kubectl
     ./kind create cluster
 }


### PR DESCRIPTION
The following PR adds two new Loki components namely the `query-scheduler` and the `index-gateway`. The rational having this two components is:
1. The `index-gateway` incorporates loading and caching the `boltdb` index files on a persistent volume that used to live in the `querier` components. In turn queriers can be transformed from `StatefulSet` to a `Deployment` enabling horizontal scaling w/o requiring any persistent volumes anymore.
2. The `query-scheduler` incorporates the scheduling logic of multi-tenant and time-range shardable queries that used to live in the `query-frontend` and `querier` components. In turn both `query-frontend` and `querier` can be scaled horizontally without tuning the concurrency settings (e.g. `max_concurrent`). These settings will be tuned by the querier automatically based on the amount of available schedulers rather query-frontends.

In summary the proposed changes simplify horizontal scaling of the query path by making externalizing operations to dedicated components that can operate with a static replica count over time. This enables a more elastic scaling behavior of the main work horses in the query path, i.e.:
- The `query_frontend` can be scale out based on the incoming http traffic requests w/o a need to inform queries of their current replica count and tune latter's internal concurrency settings.
- The `queriers` can be scaled out as simple deployments and thus provide more query processing power w/o requiring persistent volumes.

(cc @xperimental)