### PR TITLE
loki: Add service monitors for query_scheduler and index_gateway

### DIFF
--- a/configuration/components/loki.libsonnet
+++ b/configuration/components/loki.libsonnet
@@ -675,7 +675,7 @@ function(params) {
       },
     }
     for name in std.objectFields(loki.config.components)
-    if std.member(['compactor', 'distributor', 'query_frontend', 'querier', 'ingester'], name)
+    if std.member(['compactor', 'distributor', 'query_frontend', 'querier', 'query_scheduler', 'ingester', 'index_gateway'], name)
   },
 
   manifests: {


### PR DESCRIPTION
This PR adds the missing service monitor support for the loki query-scheduler and index-gateway components. Missed to add in #463 