### PR TITLE
Fix optional manifests

### DIFF
--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -157,11 +157,12 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     } + {
       ['thanos-' + name]: obs.thanos.manifests[name]
       for name in std.objectFields(obs.thanos.manifests)
-    } + if std.objectHas(obs.loki, 'manifests') then {
-      ['loki-' + name]: obs.loki.manifests[name]
-      for name in std.objectFields(obs.loki.manifests)
-    } + if obs.tracing.config.enabled then {
-      ['tracing-' + name]: obs.tracing.manifests[name]
-      for name in std.objectFields(obs.tracing.manifests)
-    } else {},
+    } + (if std.objectHas(obs.loki, 'manifests') then {
+           ['loki-' + name]: obs.loki.manifests[name]
+           for name in std.objectFields(obs.loki.manifests)
+         } else {})
+    + (if obs.tracing.config.enabled then {
+         ['tracing-' + name]: obs.tracing.manifests[name]
+         for name in std.objectFields(obs.tracing.manifests)
+       } else {}),
 }


### PR DESCRIPTION
This PR fixes an issue where importing latest `observatorium.libsonnet` causes errors like 
```
RUNTIME ERROR: Unexpected type null, expected object
	vendor/github.com/observatorium/observatorium/configuration/components/observatorium.libsonnet:(145:5)-(162:14)	object <anonymous>
	services/observatorium-template.jsonnet:11:36-49	thunk from <object <anonymous>>
	<std>:1293:24-25	thunk from <function <anonymous>>
	<std>:1293:5-33	function <anonymous>
	services/observatorium-template.jsonnet:11:19-50	object <anonymous>
	services/observatorium-template.jsonnet:(7:5)-(15:6)	
	During manifestation	
```
This is due to if-else blocks not being evaluated correctly, in `manifests` field.