### PR TITLE
macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ From the very beginning our teams were leveraging Open Source to accomplish all 
 
 ## What's Included
 
-* [Observatorium](https://github.com/observatorium/observatorium) is primarily defined in [jsonnet](https://jsonnet.org/), which allows great flexibility and reusability. The main configuration resources are stored in [components](https://github.com/observatorium/observatorium/tree/main/configuration/components) directory, and they import further official resources like [kube-thanos](https://github.com/thanos-io/kube-thanos). Some Examples:
+* [Observatorium](https://github.com/observatorium/observatorium) is primarily defined in [Jsonnet](https://jsonnet.org/), which allows great flexibility and reusability. The main configuration resources are stored in [components](https://github.com/observatorium/observatorium/tree/main/configuration/components) directory, and they import further official resources like [kube-thanos](https://github.com/thanos-io/kube-thanos). Some Examples:
   * You can see examples of how it can be used in different variations/environments [here](https://github.com/observatorium/observatorium/tree/main/configuration/examples).
   * Our [Red Hat Observability Service](https://github.com/rhobs/configuration) is also build on Observatorium.
 
-* We are aware that not everybody speaks jsonnet, and not everybody have it's own GitOps pipeline, so we designed alternative deployments based on the main jsonnet resources. [Operator](https://github.com/observatorium/operator) project delivers Kubernetes plain Operator that operates Observatorium.
+* We are aware that not everybody speaks Jsonnet, and not everybody have it's own GitOps pipeline, so we designed alternative deployments based on the main Jsonnet resources. [Operator](https://github.com/observatorium/operator) project delivers Kubernetes plain Operator that operates Observatorium.
 
 > NOTE: Observatorium is set of cloud native, mostly stateless components that mostly does not special operating logic. For those operations that required automation, specialized controllers were designed. Use Operator only if this is your primary installation logic or if you don't have CI pipeline.
 

--- a/configuration/Makefile
+++ b/configuration/Makefile
@@ -11,6 +11,12 @@ RNDR ?= ../../rndr/.bin/rndr # DEBUG
 
 JSONNET_SRC = $(shell find . -type f -not -path './*vendor/*' \( -name '*.libsonnet' -o -name '*.jsonnet' \))
 
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+   # Overcome Mac default limiting xargs -I replace size.
+   XARGS_FLAGS ?= -S 4096
+endif
+
 all: generate validate
 
 render:
@@ -41,31 +47,34 @@ validate: $(KUBEVAL) generate
 	$(KUBEVAL) --ignore-missing-schemas examples/base/manifests/*.yaml examples/dev/manifests/*.yaml examples/local/manifests/*.yaml tests/manifests/*.yaml
 
 examples/base/manifests: examples/base/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
+	echo ecs "$OS"
 	-make fmt
 	-rm -rf examples/base/manifests
 	-mkdir examples/base/manifests
-	$(JSONNET) -J vendor -m examples/base/manifests examples/base/main.jsonnet | xargs -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m examples/base/manifests examples/base/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/base/manifests -type f ! -name '*.yaml' -delete
 
 examples/dev/manifests: examples/dev/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/dev/manifests
 	-mkdir examples/dev/manifests
-	$(JSONNET) -J vendor -m examples/dev/manifests examples/dev/main.jsonnet | xargs -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m examples/dev/manifests examples/dev/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/dev/manifests -type f ! -name '*.yaml' -delete
 
+# Use Jsonnet to generate JSON versions of K8s manifests without .json extensions,
+# then send all the JSON through xargs to be converted into YAML and given .yaml extension
 examples/local/manifests: examples/local/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/local/manifests
 	-mkdir examples/local/manifests
-	$(JSONNET) -J vendor -m examples/local/manifests examples/local/main.jsonnet | xargs -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m examples/local/manifests examples/local/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/local/manifests -type f ! -name '*.yaml' -delete
 
 tests/manifests: tests/main.jsonnet vendor generate-cert $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf tests/manifests
 	-mkdir tests/manifests
-	$(JSONNET) -J vendor -m tests/manifests tests/main.jsonnet | xargs -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m tests/manifests tests/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find tests/manifests -type f ! -name '*.yaml' -delete
 
 .PHONY: generate-cert

--- a/configuration/Makefile
+++ b/configuration/Makefile
@@ -13,8 +13,11 @@ JSONNET_SRC = $(shell find . -type f -not -path './*vendor/*' \( -name '*.libson
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
-   # Overcome Mac default limiting xargs -I replace size.
-   XARGS_FLAGS ?= -S 4096
+   # macOS/BSD xargs not compatible with this Makefile (because of -S replsize default of 256).
+   # (Use for example `brew install findutils` to get gxargs).
+   XARGS ?= gxargs
+else
+   XARGS ?= xargs
 endif
 
 all: generate validate
@@ -37,7 +40,7 @@ fmt: $(JSONNETFMT) $(JSONNET_SRC)
 
 .PHONY: lint
 lint: $(JSONNET_LINT) vendor
-	echo ${JSONNET_SRC} | xargs -n 1 -- $(JSONNET_LINT) -J vendor
+	echo ${JSONNET_SRC} | $(XARGS) -n 1 -- $(JSONNET_LINT) -J vendor
 
 .PHONY: generate
 generate: examples/base/manifests examples/dev/manifests examples/local/manifests
@@ -53,28 +56,28 @@ examples/base/manifests: examples/base/main.jsonnet vendor $(JSONNET_SRC) $(JSON
 	-make fmt
 	-rm -rf examples/base/manifests
 	-mkdir examples/base/manifests
-	$(JSONNET) -J vendor -m examples/base/manifests examples/base/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m examples/base/manifests examples/base/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/base/manifests -type f ! -name '*.yaml' -delete
 
 examples/dev/manifests: examples/dev/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/dev/manifests
 	-mkdir examples/dev/manifests
-	$(JSONNET) -J vendor -m examples/dev/manifests examples/dev/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m examples/dev/manifests examples/dev/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/dev/manifests -type f ! -name '*.yaml' -delete
 
 examples/local/manifests: examples/local/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/local/manifests
 	-mkdir examples/local/manifests
-	$(JSONNET) -J vendor -m examples/local/manifests examples/local/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m examples/local/manifests examples/local/main.jsonnet | $(XARGS) -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/local/manifests -type f ! -name '*.yaml' -delete
 
 tests/manifests: tests/main.jsonnet vendor generate-cert $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf tests/manifests
 	-mkdir tests/manifests
-	$(JSONNET) -J vendor -m tests/manifests tests/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -m tests/manifests tests/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find tests/manifests -type f ! -name '*.yaml' -delete
 
 .PHONY: generate-cert

--- a/configuration/Makefile
+++ b/configuration/Makefile
@@ -46,6 +46,8 @@ generate: examples/base/manifests examples/dev/manifests examples/local/manifest
 validate: $(KUBEVAL) generate
 	$(KUBEVAL) --ignore-missing-schemas examples/base/manifests/*.yaml examples/dev/manifests/*.yaml examples/local/manifests/*.yaml tests/manifests/*.yaml
 
+# Use Jsonnet to generate JSON versions of K8s manifests without .json extensions,
+# then send all the JSON through xargs to be converted into YAML and given .yaml extension.
 examples/base/manifests: examples/base/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	echo ecs "$OS"
 	-make fmt
@@ -61,8 +63,6 @@ examples/dev/manifests: examples/dev/main.jsonnet vendor $(JSONNET_SRC) $(JSONNE
 	$(JSONNET) -J vendor -m examples/dev/manifests examples/dev/main.jsonnet | xargs -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/dev/manifests -type f ! -name '*.yaml' -delete
 
-# Use Jsonnet to generate JSON versions of K8s manifests without .json extensions,
-# then send all the JSON through xargs to be converted into YAML and given .yaml extension
 examples/local/manifests: examples/local/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/local/manifests

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -3,7 +3,7 @@
 This contains configuration for deploying the Observatorium platform.
 Currently, this includes:
 
-0. jsonnet files for advanced customization of the platform;
+0. Jsonnet files for advanced customization of the platform;
 0. example Kubernetes manifests to directly deploy Observatorium.
 
 TODO(bwplotka): Add more information.


### PR DESCRIPTION
Resolves https://github.com/observatorium/observatorium/issues/470

macOS includes a BSD-derived `xargs`, with very different flags from the GNU `xargs` on Linux systems.
See: https://www.freebsd.org/cgi/man.cgi?xargs
