### PR TITLE
add jaeger ui default settings

### DIFF
--- a/configuration/components/tracing.libsonnet
+++ b/configuration/components/tracing.libsonnet
@@ -93,6 +93,29 @@ function(params) {
       },
       spec: {
         strategy: 'allinone',
+        ui: {
+          options: {
+            dependencies: {
+              menuEnabled: false,
+            },
+            menu: [
+              {
+                items: [
+                  {
+                    label: 'Documentation',
+                    url: 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/distributed_tracing/index',
+                  },
+                ],
+                label: 'About',
+              },
+              {
+                anchorTarget: '_self',
+                label: 'Log Out',
+                url: './login',
+              },
+            ],
+          },
+        },
       },
     },
   manifests: {

--- a/configuration/components/tracing.libsonnet
+++ b/configuration/components/tracing.libsonnet
@@ -92,6 +92,23 @@ function(params) {
         labels: newCommonLabels(component),
       },
       spec: tracing.config.jaegerSpec,
+    } + {
+      spec+: {
+        ui+: {
+          options+: {
+            menu+: [
+              {
+                anchorTarget: '_self',
+                label: 'Log Out',
+                url: './login',
+              },
+            ],
+            dependencies: {
+              menuEnabled: false,
+            },
+          },
+        },
+      },
     },
   manifests: {
     otelcollector: tracing.otelcolcr,

--- a/configuration/components/tracing.libsonnet
+++ b/configuration/components/tracing.libsonnet
@@ -93,29 +93,7 @@ function(params) {
       },
       spec: {
         strategy: 'allinone',
-        ui: {
-          options: {
-            dependencies: {
-              menuEnabled: false,
-            },
-            menu: [
-              {
-                items: [
-                  {
-                    label: 'Documentation',
-                    url: 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/distributed_tracing/index',
-                  },
-                ],
-                label: 'About',
-              },
-              {
-                anchorTarget: '_self',
-                label: 'Log Out',
-                url: './login',
-              },
-            ],
-          },
-        },
+        ui: tracing.config.jaegerUI,
       },
     },
   manifests: {

--- a/configuration/components/tracing.libsonnet
+++ b/configuration/components/tracing.libsonnet
@@ -91,10 +91,7 @@ function(params) {
         namespace: tracing.config.namespace,
         labels: newCommonLabels(component),
       },
-      spec: {
-        strategy: tracing.config.jaeger.strategy,
-        ui: tracing.config.jaeger.ui,
-      },
+      spec: tracing.config.jaegerSpec,
     },
   manifests: {
     otelcollector: tracing.otelcolcr,

--- a/configuration/components/tracing.libsonnet
+++ b/configuration/components/tracing.libsonnet
@@ -92,8 +92,8 @@ function(params) {
         labels: newCommonLabels(component),
       },
       spec: {
-        strategy: 'allinone',
-        ui: tracing.config.jaegerUI,
+        strategy: tracing.config.jaeger.strategy,
+        ui: tracing.config.jaeger.ui,
       },
     },
   manifests: {

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -21,6 +21,29 @@ local dev = obs {
     obs.tracing.config {
       tenants: [tenant.name],
       enabled: true,
+      jaegerUI: {
+        options: {
+          dependencies: {
+            menuEnabled: false,
+          },
+          menu: [
+            {
+              items: [
+                {
+                  label: 'Documentation',
+                  url: 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/distributed_tracing/index',
+                },
+              ],
+              label: 'About',
+            },
+            {
+              anchorTarget: '_self',
+              label: 'Log Out',
+              url: './login',
+            },
+          ],
+        },
+      },
     },
   ),
   api: api(

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -21,7 +21,7 @@ local dev = obs {
     obs.tracing.config {
       tenants: [tenant.name],
       enabled: true,
-      jaeger: {
+      jaegerSpec: {
         strategy: 'allinone',
         ui: {
           options: {

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -25,9 +25,6 @@ local dev = obs {
         strategy: 'allinone',
         ui: {
           options: {
-            dependencies: {
-              menuEnabled: false,
-            },
             menu: [
               {
                 items: [
@@ -37,11 +34,6 @@ local dev = obs {
                   },
                 ],
                 label: 'About',
-              },
-              {
-                anchorTarget: '_self',
-                label: 'Log Out',
-                url: './login',
               },
             ],
           },

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -21,27 +21,30 @@ local dev = obs {
     obs.tracing.config {
       tenants: [tenant.name],
       enabled: true,
-      jaegerUI: {
-        options: {
-          dependencies: {
-            menuEnabled: false,
+      jaeger: {
+        strategy: 'allinone',
+        ui: {
+          options: {
+            dependencies: {
+              menuEnabled: false,
+            },
+            menu: [
+              {
+                items: [
+                  {
+                    label: 'Documentation',
+                    url: 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/distributed_tracing/index',
+                  },
+                ],
+                label: 'About',
+              },
+              {
+                anchorTarget: '_self',
+                label: 'Log Out',
+                url: './login',
+              },
+            ],
           },
-          menu: [
-            {
-              items: [
-                {
-                  label: 'Documentation',
-                  url: 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/distributed_tracing/index',
-                },
-              ],
-              label: 'About',
-            },
-            {
-              anchorTarget: '_self',
-              label: 'Log Out',
-              url: './login',
-            },
-          ],
         },
       },
     },

--- a/configuration/examples/local/manifests/tracing-jaeger-test-oidc.yaml
+++ b/configuration/examples/local/manifests/tracing-jaeger-test-oidc.yaml
@@ -10,3 +10,15 @@ metadata:
   namespace: observatorium
 spec:
   strategy: allinone
+  ui:
+    options:
+      dependencies:
+        menuEnabled: false
+      menu:
+      - items:
+        - label: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/distributed_tracing/index
+        label: About
+      - anchorTarget: _self
+        label: Log Out
+        url: ./login


### PR DESCRIPTION
In Jaeger, ui modifications can be made via a [ui config](https://www.jaegertracing.io/docs/1.32/frontend-ui/#configuration). The operator supports a configuration directly via [CR entry](https://www.jaegertracing.io/docs/1.32/operator/#configuring-the-ui). This pr extends the tracing lib by this field.

Tracing is enabled in the local example, there i added an example configuration.

Happy to hear your thoughts on this.

---

cc @esnible @pavolloffay 