### PR TITLE
Don't deploy API to forward unless tracing enabled

### DIFF
--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -79,7 +79,13 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
       ],
     },
     traces: {
+      // gRPC OpenTelemetry collector for traces endpoint
       writeEndpoint: obs.tracing.manifests.otelcollector.metadata.name + '-collector:4317',
+
+      // Jaeger V2 HTTP query for traces using Observatorium tenancy pattern
+      templateEndpoint: 'http://jaeger-{tenant}-collector:16686',
+
+      enabled: false,
     },
     rateLimiter: {
       grpcAddress: '%s.%s.svc.cluster.local:%d' % [

--- a/configuration/examples/base/manifests/api-deployment.yaml
+++ b/configuration/examples/base/manifests/api-deployment.yaml
@@ -40,8 +40,6 @@ spec:
         - --logs.read.endpoint=http://observatorium-xyz-loki-query-frontend-http.observatorium.svc.cluster.local:3100
         - --logs.tail.endpoint=http://observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
-        - --traces.write.endpoint=observatorium-xyz-otel-collector:4317
-        - --grpc.listen=0.0.0.0:8090
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
         image: quay.io/observatorium/api:main-2022-03-03-v0.1.2-139-gb3a1918
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/dev/manifests/api-deployment.yaml
+++ b/configuration/examples/dev/manifests/api-deployment.yaml
@@ -40,8 +40,6 @@ spec:
         - --logs.read.endpoint=http://observatorium-xyz-loki-query-frontend-http.observatorium.svc.cluster.local:3100
         - --logs.tail.endpoint=http://observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
-        - --traces.write.endpoint=observatorium-xyz-otel-collector:4317
-        - --grpc.listen=0.0.0.0:8090
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081

--- a/configuration/examples/local/main.jsonnet
+++ b/configuration/examples/local/main.jsonnet
@@ -25,6 +25,11 @@ local dev = obs {
   ),
   api: api(
     obs.api.config {
+      traces: {
+        writeEndpoint: obs.api.config.traces.writeEndpoint,
+        templateEndpoint: obs.api.config.traces.templateEndpoint,
+        enabled: true,
+      },
       rbac: {
         roles: [
           {

--- a/configuration/examples/local/manifests/api-deployment.yaml
+++ b/configuration/examples/local/manifests/api-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
         - --traces.write.endpoint=observatorium-xyz-otel-collector:4317
         - --grpc.listen=0.0.0.0:8090
+        - --experimental.traces.read.endpoint-template=http://jaeger-{tenant}-collector:16686
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081


### PR DESCRIPTION
This PR implements half of a fix for https://github.com/observatorium/observatorium/issues/472

The other half is https://github.com/observatorium/api/pull/280 in the observatorium/api repo.
This PR will not change the behavior of the generated manifests until the other PR is merged.

I am creating this PR as a draft, so that it doesn't accidentally get merged before [271](https://github.com/observatorium/api/pull/280).

cc @pavolloffay @jessicalins 