### PR TITLE
Add redoc for OpenAPI spec based documentation

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Observatorium API Specification</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet" />
+
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <redoc spec-url="https://raw.githubusercontent.com/observatorium/api/main/client/spec.yaml"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
+</body>
+
+</html>

--- a/docs/api.html
+++ b/docs/api.html
@@ -2,6 +2,33 @@
 <html>
 
 <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <meta name="robots" content="index, follow">
+    <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+    <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+    <meta name="description" content="Observatorium API Documentation">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="/observatorium.png">
+    <meta name="twitter:title" content="Observatorium">
+    <meta name="twitter:description" content="Observatorium API Documentation">
+
+    <meta property="og:title" content="Observatorium">
+    <meta property="og:description" content="Observatorium API Documentation">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="/observatorium.png" />
+    <meta property="og:site_name" content="Observatorium">
+
+    <meta property="og:locale" content="en_US">
+
+    <meta name="theme-color" content="#fff">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+
     <title>Observatorium API Specification</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -16,7 +43,8 @@
 </head>
 
 <body>
-    <redoc spec-url="https://raw.githubusercontent.com/observatorium/api/main/client/spec.yaml"></redoc>
+    <redoc spec-url="https://raw.githubusercontent.com/observatorium/api/main/client/spec.yaml">
+    </redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
 </body>
 

--- a/website/config/_default/menus.toml
+++ b/website/config/_default/menus.toml
@@ -45,6 +45,11 @@
   url = "/docs/usage/getting-started.md/"
   weight = 10
 
+[[main]]
+  name = "API"
+  url = "/docs/api.html/"
+  weight = 10
+
 # [[main]]
 #   name = "Blog"
 #   url = "/blog/"


### PR DESCRIPTION
This PR adds an API documentation page for Observatorium using [redocly](https://redocly.com/).
