### PR TITLE
Remove volumes for loki ruler when using s3 storage

### DIFF
--- a/configuration/components/loki.libsonnet
+++ b/configuration/components/loki.libsonnet
@@ -630,7 +630,7 @@ function(params) {
       volumeMounts: [
         { name: 'config', mountPath: '/etc/loki/config/', readOnly: false },
         { name: 'storage', mountPath: '/data', readOnly: false },
-      ] + if component == 'ruler' then [rulesVolumeMount] else [],
+      ] + if component == 'ruler' && loki.config.rulesStorageConfig.type == 'local' then [rulesVolumeMount] else [],
     } + {
       [name]: readinessProbe[name]
       for name in std.objectFields(readinessProbe)
@@ -709,7 +709,7 @@ function(params) {
             containers: [newLokiContainer(name, component, config)],
             volumes: [
               { name: 'config', configMap: { name: loki.configmap.metadata.name } },
-            ] + if component == 'ruler' then [rulesVolume] else [],
+            ] + if component == 'ruler' && loki.config.rulesStorageConfig.type == 'local' then [rulesVolume] else [],
             volumeClaimTemplates:: null,
           },
         },

--- a/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -88,16 +88,10 @@ spec:
         - mountPath: /data
           name: storage
           readOnly: false
-        - mountPath: /tmp/rules
-          name: rules
-          readOnly: false
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-      - configMap:
-          name: observatorium-xyz-loki-rules
-        name: rules
   volumeClaimTemplates:
   - metadata:
       labels:

--- a/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -88,16 +88,10 @@ spec:
         - mountPath: /data
           name: storage
           readOnly: false
-        - mountPath: /tmp/rules
-          name: rules
-          readOnly: false
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-      - configMap:
-          name: observatorium-xyz-loki-rules
-        name: rules
   volumeClaimTemplates:
   - metadata:
       labels:

--- a/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -88,16 +88,10 @@ spec:
         - mountPath: /data
           name: storage
           readOnly: false
-        - mountPath: /tmp/rules
-          name: rules
-          readOnly: false
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
-      - configMap:
-          name: observatorium-xyz-loki-rules
-        name: rules
   volumeClaimTemplates:
   - metadata:
       labels:


### PR DESCRIPTION
This is a follow-up on #500 to remove static rules from a ConfigMap when the Loki Ruler config is using object storage as the default storage config.