### PR TITLE
logs: refactors ConfigMap generation to use loki.mixins

### DIFF
--- a/configuration/Makefile
+++ b/configuration/Makefile
@@ -53,6 +53,8 @@ validate: $(KUBEVAL) generate
 
 # Use Jsonnet to generate JSON versions of K8s manifests without .json extensions,
 # then send all the JSON through xargs to be converted into YAML and given .yaml extension.
+# The goal of the sed at the end is to remove quotes from an env var in the loki config, as
+# it must be read by loki as an int and not as a string
 examples/base/manifests: examples/base/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	echo ecs "$OS"
 	-make fmt
@@ -60,7 +62,7 @@ examples/base/manifests: examples/base/main.jsonnet vendor $(JSONNET_SRC) $(JSON
 	-mkdir examples/base/manifests
 	$(JSONNET) -J vendor -J lib -c -m examples/base/manifests examples/base/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/base/manifests -type f ! -name '*.yaml' -delete
-	sed -i 's/"$$\(\(.*\)\)"/$$\1/g' examples/base/manifests/observatorium/loki-config-map.yaml
+	sed -i 's/"$${LOKI_REPLICATION_FACTOR}"/$${LOKI_REPLICATION_FACTOR}/g' examples/base/manifests/observatorium/loki-config-map.yaml
 
 examples/dev/manifests: examples/dev/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
@@ -68,7 +70,7 @@ examples/dev/manifests: examples/dev/main.jsonnet vendor $(JSONNET_SRC) $(JSONNE
 	-mkdir examples/dev/manifests
 	$(JSONNET) -J vendor -J lib -c -m examples/dev/manifests examples/dev/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/dev/manifests -type f ! -name '*.yaml' -delete
-	sed -i 's/"$$\(\(.*\)\)"/$$\1/g' examples/dev/manifests/observatorium/loki-config-map.yaml
+	sed -i 's/"$${LOKI_REPLICATION_FACTOR}"/$${LOKI_REPLICATION_FACTOR}/g' examples/dev/manifests/observatorium/loki-config-map.yaml
 
 examples/local/manifests: examples/local/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
@@ -76,7 +78,7 @@ examples/local/manifests: examples/local/main.jsonnet vendor $(JSONNET_SRC) $(JS
 	-mkdir examples/local/manifests
 	$(JSONNET) -J vendor -J lib -c -m examples/local/manifests examples/local/main.jsonnet | $(XARGS) -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/local/manifests -type f ! -name '*.yaml' -delete
-	sed -i 's/"$$\(\(.*\)\)"/$$\1/g' examples/local/manifests/observatorium/loki-config-map.yaml
+	sed -i 's/"$${LOKI_REPLICATION_FACTOR}"/$${LOKI_REPLICATION_FACTOR}/g' examples/local/manifests/observatorium/loki-config-map.yaml
 
 tests/manifests: tests/main.jsonnet vendor generate-cert $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt

--- a/configuration/Makefile
+++ b/configuration/Makefile
@@ -58,28 +58,31 @@ examples/base/manifests: examples/base/main.jsonnet vendor $(JSONNET_SRC) $(JSON
 	-make fmt
 	-rm -rf examples/base/manifests
 	-mkdir examples/base/manifests
-	$(JSONNET) -J vendor -c -m examples/base/manifests examples/base/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -J lib -c -m examples/base/manifests examples/base/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/base/manifests -type f ! -name '*.yaml' -delete
+	sed -i 's/"$$\(\(.*\)\)"/$$\1/g' examples/base/manifests/observatorium/loki-config-map.yaml
 
 examples/dev/manifests: examples/dev/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/dev/manifests
 	-mkdir examples/dev/manifests
-	$(JSONNET) -J vendor -c -m examples/dev/manifests examples/dev/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -J lib -c -m examples/dev/manifests examples/dev/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/dev/manifests -type f ! -name '*.yaml' -delete
+	sed -i 's/"$$\(\(.*\)\)"/$$\1/g' examples/dev/manifests/observatorium/loki-config-map.yaml
 
 examples/local/manifests: examples/local/main.jsonnet vendor $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf examples/local/manifests
 	-mkdir examples/local/manifests
-	$(JSONNET) -J vendor -c -m examples/local/manifests examples/local/main.jsonnet | $(XARGS) -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -J lib -c -m examples/local/manifests examples/local/main.jsonnet | $(XARGS) -I{} $(XARGS_FLAGS) sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find examples/local/manifests -type f ! -name '*.yaml' -delete
+	sed -i 's/"$$\(\(.*\)\)"/$$\1/g' examples/local/manifests/observatorium/loki-config-map.yaml
 
 tests/manifests: tests/main.jsonnet vendor generate-cert $(JSONNET_SRC) $(JSONNET) $(GOJSONTOYAML)
 	-make fmt
 	-rm -rf tests/manifests
 	-mkdir tests/manifests
-	$(JSONNET) -J vendor -c -m tests/manifests tests/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
+	$(JSONNET) -J vendor -J lib -c -m tests/manifests tests/main.jsonnet | $(XARGS) -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find tests/manifests -type f ! -name '*.yaml' -delete
 
 .PHONY: generate-cert

--- a/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -32,10 +32,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-config-map.yaml
@@ -3,15 +3,16 @@ data:
   config.yaml: |-
     "analytics":
       "reporting_enabled": false
-    "auth_enabled": true
     "chunk_store_config":
       "chunk_cache_config":
         "embedded_cache":
           "enabled": true
           "max_size_mb": 500
-      "max_look_back_period": "0s"
     "common":
       "compactor_grpc_address": "observatorium-xyz-loki-compactor-grpc.observatorium.svc.cluster.local:9095"
+      "ring":
+        "kvstore":
+          "store": "memberlist"
     "compactor":
       "compaction_interval": "2h"
       "shared_store": "s3"
@@ -22,6 +23,7 @@ data:
           "store": "memberlist"
     "frontend":
       "compress_responses": true
+      "log_queries_longer_than": "5s"
       "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
       "tail_proxy_url": "observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100"
     "frontend_worker":
@@ -39,12 +41,13 @@ data:
         "heartbeat_period": "5s"
         "interface_names":
         - "eth0"
-        "join_after": "60s"
+        "join_after": "30s"
         "num_tokens": 512
         "ring":
           "heartbeat_timeout": "1m"
           "kvstore":
             "store": "memberlist"
+          "replication_factor": ${LOKI_REPLICATION_FACTOR}
       "max_transfer_retries": 0
       "wal":
         "dir": "/data/loki/wal"
@@ -57,7 +60,6 @@ data:
     "limits_config":
       "cardinality_limit": 100000
       "creation_grace_period": "10m"
-      "deletion_mode": "disabled"
       "enforce_metric_name": false
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
@@ -88,18 +90,12 @@ data:
       "max_join_retries": 10
       "min_join_backoff": "1s"
     "querier":
-      "engine":
-        "max_look_back_period": "30s"
-      "extra_query_delay": "0s"
       "max_concurrent": 2
-      "query_ingesters_within": "3h"
-      "query_timeout": "1h"
-      "tail_max_duration": "1h"
+      "query_ingesters_within": "2h"
     "query_range":
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
-      "parallelise_shardable_queries": false
       "results_cache":
         "cache":
           "embedded_cache":
@@ -118,9 +114,6 @@ data:
         "type": "s3"
       "wal":
         "dir": "/data/loki/wal"
-        "max_age": "4h"
-        "min_age": "5m"
-        "truncate_frequency": "60m"
     "schema_config":
       "configs":
       - "from": "2020-10-01"
@@ -140,15 +133,12 @@ data:
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
-      "log_level": "error"
     "storage_config":
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "cache_ttl": "24h"
         "index_gateway_client":
           "server_address": "observatorium-xyz-loki-index-gateway-grpc.observatorium.svc.cluster.local:9095"
-        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap

--- a/configuration/examples/base/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-distributor-deployment.yaml
@@ -33,10 +33,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -32,10 +32,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -34,10 +34,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-querier-deployment.yaml
@@ -33,10 +33,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -31,10 +31,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -31,10 +31,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -34,12 +34,14 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
         - -ruler.storage.s3.url=$(RULER_S3_URL)
         - -ruler.storage.s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -32,10 +32,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-config-map.yaml
@@ -3,15 +3,16 @@ data:
   config.yaml: |-
     "analytics":
       "reporting_enabled": false
-    "auth_enabled": true
     "chunk_store_config":
       "chunk_cache_config":
         "embedded_cache":
           "enabled": true
           "max_size_mb": 500
-      "max_look_back_period": "0s"
     "common":
       "compactor_grpc_address": "observatorium-xyz-loki-compactor-grpc.observatorium.svc.cluster.local:9095"
+      "ring":
+        "kvstore":
+          "store": "memberlist"
     "compactor":
       "compaction_interval": "2h"
       "shared_store": "s3"
@@ -22,6 +23,7 @@ data:
           "store": "memberlist"
     "frontend":
       "compress_responses": true
+      "log_queries_longer_than": "5s"
       "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
       "tail_proxy_url": "observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100"
     "frontend_worker":
@@ -39,12 +41,13 @@ data:
         "heartbeat_period": "5s"
         "interface_names":
         - "eth0"
-        "join_after": "60s"
+        "join_after": "30s"
         "num_tokens": 512
         "ring":
           "heartbeat_timeout": "1m"
           "kvstore":
             "store": "memberlist"
+          "replication_factor": ${LOKI_REPLICATION_FACTOR}
       "max_transfer_retries": 0
       "wal":
         "dir": "/data/loki/wal"
@@ -57,7 +60,6 @@ data:
     "limits_config":
       "cardinality_limit": 100000
       "creation_grace_period": "10m"
-      "deletion_mode": "disabled"
       "enforce_metric_name": false
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
@@ -90,16 +92,12 @@ data:
     "querier":
       "engine":
         "max_look_back_period": "5m"
-      "extra_query_delay": "0s"
       "max_concurrent": 2
-      "query_ingesters_within": "3h"
-      "query_timeout": "1h"
-      "tail_max_duration": "1h"
+      "query_ingesters_within": "2h"
     "query_range":
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
-      "parallelise_shardable_queries": false
       "results_cache":
         "cache":
           "embedded_cache":
@@ -118,9 +116,6 @@ data:
         "type": "s3"
       "wal":
         "dir": "/data/loki/wal"
-        "max_age": "4h"
-        "min_age": "5m"
-        "truncate_frequency": "60m"
     "schema_config":
       "configs":
       - "from": "2020-10-01"
@@ -140,15 +135,12 @@ data:
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
-      "log_level": "error"
     "storage_config":
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "cache_ttl": "24h"
         "index_gateway_client":
           "server_address": "observatorium-xyz-loki-index-gateway-grpc.observatorium.svc.cluster.local:9095"
-        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap

--- a/configuration/examples/dev/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-distributor-deployment.yaml
@@ -33,10 +33,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -32,10 +32,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -34,10 +34,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-querier-deployment.yaml
@@ -33,10 +33,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -31,10 +31,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -31,10 +31,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -34,12 +34,14 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
         - -ruler.storage.s3.url=$(RULER_S3_URL)
         - -ruler.storage.s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -32,10 +32,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-config-map.yaml
@@ -3,15 +3,16 @@ data:
   config.yaml: |-
     "analytics":
       "reporting_enabled": false
-    "auth_enabled": true
     "chunk_store_config":
       "chunk_cache_config":
         "embedded_cache":
           "enabled": true
           "max_size_mb": 500
-      "max_look_back_period": "0s"
     "common":
       "compactor_grpc_address": "observatorium-xyz-loki-compactor-grpc.observatorium.svc.cluster.local:9095"
+      "ring":
+        "kvstore":
+          "store": "memberlist"
     "compactor":
       "compaction_interval": "2h"
       "shared_store": "s3"
@@ -22,6 +23,7 @@ data:
           "store": "memberlist"
     "frontend":
       "compress_responses": true
+      "log_queries_longer_than": "5s"
       "scheduler_address": "observatorium-xyz-loki-query-scheduler-grpc.observatorium.svc.cluster.local:9095"
       "tail_proxy_url": "observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100"
     "frontend_worker":
@@ -39,12 +41,13 @@ data:
         "heartbeat_period": "5s"
         "interface_names":
         - "eth0"
-        "join_after": "60s"
+        "join_after": "30s"
         "num_tokens": 512
         "ring":
           "heartbeat_timeout": "1m"
           "kvstore":
             "store": "memberlist"
+          "replication_factor": ${LOKI_REPLICATION_FACTOR}
       "max_transfer_retries": 0
       "wal":
         "dir": "/data/loki/wal"
@@ -57,7 +60,6 @@ data:
     "limits_config":
       "cardinality_limit": 100000
       "creation_grace_period": "10m"
-      "deletion_mode": "disabled"
       "enforce_metric_name": false
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
@@ -88,18 +90,12 @@ data:
       "max_join_retries": 10
       "min_join_backoff": "1s"
     "querier":
-      "engine":
-        "max_look_back_period": "30s"
-      "extra_query_delay": "0s"
       "max_concurrent": 2
-      "query_ingesters_within": "3h"
-      "query_timeout": "1h"
-      "tail_max_duration": "1h"
+      "query_ingesters_within": "2h"
     "query_range":
       "align_queries_with_step": true
       "cache_results": true
       "max_retries": 5
-      "parallelise_shardable_queries": false
       "results_cache":
         "cache":
           "embedded_cache":
@@ -118,9 +114,6 @@ data:
         "type": "s3"
       "wal":
         "dir": "/data/loki/wal"
-        "max_age": "4h"
-        "min_age": "5m"
-        "truncate_frequency": "60m"
     "schema_config":
       "configs":
       - "from": "2020-10-01"
@@ -140,15 +133,12 @@ data:
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
-      "log_level": "error"
     "storage_config":
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "cache_ttl": "24h"
         "index_gateway_client":
           "server_address": "observatorium-xyz-loki-index-gateway-grpc.observatorium.svc.cluster.local:9095"
-        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap

--- a/configuration/examples/local/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-distributor-deployment.yaml
@@ -33,10 +33,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -32,10 +32,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -34,10 +34,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-querier-deployment.yaml
@@ -33,10 +33,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -31,10 +31,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -31,10 +31,12 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -34,12 +34,14 @@ spec:
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -log.level=error
+        - -config.expand-env=true
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
         - -ruler.storage.s3.url=$(RULER_S3_URL)
         - -ruler.storage.s3.force-path-style=true
-        - -distributor.replication-factor=1
         env:
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/jsonnetfile.json
+++ b/configuration/jsonnetfile.json
@@ -4,6 +4,24 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/loki"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.26"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/observatorium/api.git",
           "subdir": "jsonnet/lib"
         }

--- a/configuration/jsonnetfile.lock.json
+++ b/configuration/jsonnetfile.lock.json
@@ -45,11 +45,71 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "consul"
+        }
+      },
+      "version": "0c3703518707800bd674530672a6669f582819aa",
+      "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "grafana-builder"
         }
       },
       "version": "9ce44b845bdf4258a755b58087025c271f61b5bf",
       "sum": "0KkygBQd/AFzUvVzezE4qF/uDYgrwUXVpZfINBti0oc="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "jaeger-agent-mixin"
+        }
+      },
+      "version": "0c3703518707800bd674530672a6669f582819aa",
+      "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "0c3703518707800bd674530672a6669f582819aa",
+      "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "memcached"
+        }
+      },
+      "version": "0c3703518707800bd674530672a6669f582819aa",
+      "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/loki"
+        }
+      },
+      "version": "e773c004f5b671298e1136ca435d6e7ea55b2ae1",
+      "sum": "TzYVDF0DQfzP+pZT43DuLIV47g2f3ZuXYLeMEr3EB+w="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.26"
+        }
+      },
+      "version": "9e5b48eee32913938d3cac30f183b49ecd9fe13a",
+      "sum": "7pl3HQqiKg4zJ0dWFqMo9yMGDEvlVdxgPGr1rMm0/LE="
     },
     {
       "source": {

--- a/configuration/lib/k.libsonnet
+++ b/configuration/lib/k.libsonnet
@@ -1,0 +1,1 @@
+(import 'github.com/jsonnet-libs/k8s-libsonnet/1.26/main.libsonnet')


### PR DESCRIPTION
Issue: [issues.redhat.com/browse/LOG-3900](https://issues.redhat.com/browse/LOG-3900)

In this PR refactors loki.libsonnet to use the loxi mixins to generate the ConfigMap containing the loki config. Furthermore, this PR moves the replication factor config to the ConfigMap and takes advantage of env var expansion for loki to pick up this config.
