### PR TITLE
logs: moves some loki CLI args to the config

### DIFF
--- a/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -31,13 +31,12 @@ spec:
         - -target=compactor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -33,10 +33,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-config-map.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-config-map.yaml
@@ -55,7 +55,7 @@ data:
       "wal":
         "dir": "/data/loki/wal"
         "enabled": true
-        "replay_memory_ceiling": "100MB"
+        "replay_memory_ceiling": ${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING}
     "ingester_client":
       "grpc_client_config":
         "max_recv_msg_size": 67108864
@@ -93,7 +93,7 @@ data:
       "max_join_retries": 10
       "min_join_backoff": "1s"
     "querier":
-      "max_concurrent": 2
+      "max_concurrent": ${LOKI_QUERIER_MAX_CONCURRENCY}
       "query_ingesters_within": "2h"
     "query_range":
       "align_queries_with_step": true
@@ -114,6 +114,9 @@ data:
           "store": "memberlist"
       "rule_path": "/data"
       "storage":
+        "s3":
+          "s3": "${RULER_S3_URL}"
+          "s3forcepathstyle": true
         "type": "s3"
       "wal":
         "dir": "/data/loki/wal"
@@ -136,7 +139,11 @@ data:
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
+      "log_level": "${LOKI_LOG_LEVEL}"
     "storage_config":
+      "aws":
+        "s3": "${S3_URL}"
+        "s3forcepathstyle": true
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"

--- a/configuration/examples/base/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-distributor-deployment.yaml
@@ -34,10 +34,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-distributor-deployment.yaml
@@ -32,13 +32,12 @@ spec:
         - -target=distributor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -31,13 +31,12 @@ spec:
         - -target=index-gateway
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -33,10 +33,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -35,10 +35,12 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
         - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
           value: 100MB
         - name: S3_URL

--- a/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -33,13 +33,14 @@ spec:
         - -target=ingester
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-querier-deployment.yaml
@@ -34,12 +34,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: LOKI_QUERIER_MAX_CONCURRENCY
           value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-querier-deployment.yaml
@@ -32,13 +32,14 @@ spec:
         - -target=querier
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -30,13 +30,12 @@ spec:
         - -target=query-frontend
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -32,10 +32,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -32,10 +32,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -30,13 +30,12 @@ spec:
         - -target=query-scheduler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -35,10 +35,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -33,15 +33,12 @@ spec:
         - -target=ruler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
-        - -ruler.storage.s3.url=$(RULER_S3_URL)
-        - -ruler.storage.s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -31,13 +31,12 @@ spec:
         - -target=compactor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -33,10 +33,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-config-map.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-config-map.yaml
@@ -55,7 +55,7 @@ data:
       "wal":
         "dir": "/data/loki/wal"
         "enabled": true
-        "replay_memory_ceiling": "100MB"
+        "replay_memory_ceiling": ${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING}
     "ingester_client":
       "grpc_client_config":
         "max_recv_msg_size": 67108864
@@ -95,7 +95,7 @@ data:
     "querier":
       "engine":
         "max_look_back_period": "5m"
-      "max_concurrent": 2
+      "max_concurrent": ${LOKI_QUERIER_MAX_CONCURRENCY}
       "query_ingesters_within": "2h"
     "query_range":
       "align_queries_with_step": true
@@ -116,6 +116,9 @@ data:
           "store": "memberlist"
       "rule_path": "/data"
       "storage":
+        "s3":
+          "s3": "${RULER_S3_URL}"
+          "s3forcepathstyle": true
         "type": "s3"
       "wal":
         "dir": "/data/loki/wal"
@@ -138,7 +141,11 @@ data:
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
+      "log_level": "${LOKI_LOG_LEVEL}"
     "storage_config":
+      "aws":
+        "s3": "${S3_URL}"
+        "s3forcepathstyle": true
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"

--- a/configuration/examples/dev/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-distributor-deployment.yaml
@@ -34,10 +34,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-distributor-deployment.yaml
@@ -32,13 +32,12 @@ spec:
         - -target=distributor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -31,13 +31,12 @@ spec:
         - -target=index-gateway
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -33,10 +33,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -35,10 +35,12 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
         - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
           value: 100MB
         - name: S3_URL

--- a/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -33,13 +33,14 @@ spec:
         - -target=ingester
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-querier-deployment.yaml
@@ -34,12 +34,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: LOKI_QUERIER_MAX_CONCURRENCY
           value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-querier-deployment.yaml
@@ -32,13 +32,14 @@ spec:
         - -target=querier
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -30,13 +30,12 @@ spec:
         - -target=query-frontend
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -32,10 +32,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -32,10 +32,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -30,13 +30,12 @@ spec:
         - -target=query-scheduler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -35,10 +35,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -33,15 +33,12 @@ spec:
         - -target=ruler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
-        - -ruler.storage.s3.url=$(RULER_S3_URL)
-        - -ruler.storage.s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -31,13 +31,12 @@ spec:
         - -target=compactor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -33,10 +33,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-config-map.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-config-map.yaml
@@ -55,7 +55,7 @@ data:
       "wal":
         "dir": "/data/loki/wal"
         "enabled": true
-        "replay_memory_ceiling": "100MB"
+        "replay_memory_ceiling": ${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING}
     "ingester_client":
       "grpc_client_config":
         "max_recv_msg_size": 67108864
@@ -93,7 +93,7 @@ data:
       "max_join_retries": 10
       "min_join_backoff": "1s"
     "querier":
-      "max_concurrent": 2
+      "max_concurrent": ${LOKI_QUERIER_MAX_CONCURRENCY}
       "query_ingesters_within": "2h"
     "query_range":
       "align_queries_with_step": true
@@ -114,6 +114,9 @@ data:
           "store": "memberlist"
       "rule_path": "/data"
       "storage":
+        "s3":
+          "s3": "${RULER_S3_URL}"
+          "s3forcepathstyle": true
         "type": "s3"
       "wal":
         "dir": "/data/loki/wal"
@@ -136,7 +139,11 @@ data:
       "http_listen_port": 3100
       "http_server_idle_timeout": "120s"
       "http_server_write_timeout": "1m"
+      "log_level": "${LOKI_LOG_LEVEL}"
     "storage_config":
+      "aws":
+        "s3": "${S3_URL}"
+        "s3forcepathstyle": true
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"

--- a/configuration/examples/local/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-distributor-deployment.yaml
@@ -34,10 +34,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-distributor-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-distributor-deployment.yaml
@@ -32,13 +32,12 @@ spec:
         - -target=distributor
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -31,13 +31,12 @@ spec:
         - -target=index-gateway
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -33,10 +33,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -35,10 +35,12 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
         - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
           value: 100MB
         - name: S3_URL

--- a/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -33,13 +33,14 @@ spec:
         - -target=ingester
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-querier-deployment.yaml
@@ -34,12 +34,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
         - name: LOKI_QUERIER_MAX_CONCURRENCY
           value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-querier-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-querier-deployment.yaml
@@ -32,13 +32,14 @@ spec:
         - -target=querier
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -30,13 +30,12 @@ spec:
         - -target=query-frontend
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-query-frontend-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-query-frontend-deployment.yaml
@@ -32,10 +32,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -32,10 +32,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-query-scheduler-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-query-scheduler-deployment.yaml
@@ -30,13 +30,12 @@ spec:
         - -target=query-scheduler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -35,10 +35,14 @@ spec:
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
         - -config.expand-env=true
         env:
-        - name: LOKI_REPLICATION_FACTOR
-          value: "1"
         - name: LOKI_LOG_LEVEL
           value: info
+        - name: LOKI_REPLICATION_FACTOR
+          value: "1"
+        - name: LOKI_QUERIER_MAX_CONCURRENCY
+          value: "2"
+        - name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+          value: 100MB
         - name: S3_URL
           valueFrom:
             secretKeyRef:

--- a/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -33,15 +33,12 @@ spec:
         - -target=ruler
         - -config.file=/etc/loki/config/config.yaml
         - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
-        - -log.level=error
         - -config.expand-env=true
-        - -s3.url=$(S3_URL)
-        - -s3.force-path-style=true
-        - -ruler.storage.s3.url=$(RULER_S3_URL)
-        - -ruler.storage.s3.force-path-style=true
         env:
         - name: LOKI_REPLICATION_FACTOR
           value: "1"
+        - name: LOKI_LOG_LEVEL
+          value: info
         - name: S3_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/LOG-3902

Moves some loki configuration that previously was being passed by CLI arguments to the loki config directly in the form of ENV vars that will then be expanded to their actual values. We need this because upstream we will want to update these values without having to regenerate the templates. Furthermore, some of the values are secrets and are only known at rollout time