### PR TITLE
logs: moves statefulsets to loki mixins

### DIFF
--- a/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
@@ -58,15 +59,15 @@ spec:
         name: observatorium-xyz-loki-compactor
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
-          initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
           limits:
@@ -78,16 +79,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
@@ -58,15 +59,15 @@ spec:
         name: observatorium-xyz-loki-index-gateway
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
-          initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
           limits:
@@ -78,16 +79,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -17,7 +18,6 @@ spec:
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
   serviceName: observatorium-xyz-loki-ingester
   template:
     metadata:
@@ -60,7 +60,7 @@ spec:
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
         - containerPort: 7946
@@ -69,7 +69,6 @@ spec:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
@@ -82,16 +81,21 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
+      terminationGracePeriodSeconds: 4800
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/base/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-loki-ruler
   namespace: observatorium
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -17,7 +18,6 @@ spec:
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
   serviceName: observatorium-xyz-loki-ruler
   template:
     metadata:
@@ -65,7 +65,7 @@ spec:
         name: observatorium-xyz-loki-ruler
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
         - containerPort: 7946
@@ -74,7 +74,6 @@ spec:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
@@ -87,16 +86,25 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+        - mountPath: /tmp/rules
+          name: rules
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+      - configMap:
+          name: observatorium-xyz-loki-rules
+        name: rules
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
@@ -58,15 +59,15 @@ spec:
         name: observatorium-xyz-loki-compactor
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
-          initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
           limits:
@@ -78,16 +79,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
@@ -58,15 +59,15 @@ spec:
         name: observatorium-xyz-loki-index-gateway
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
-          initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
           limits:
@@ -78,16 +79,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -17,7 +18,6 @@ spec:
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
   serviceName: observatorium-xyz-loki-ingester
   template:
     metadata:
@@ -60,7 +60,7 @@ spec:
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
         - containerPort: 7946
@@ -69,7 +69,6 @@ spec:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
@@ -82,16 +81,21 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
+      terminationGracePeriodSeconds: 4800
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/dev/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-loki-ruler
   namespace: observatorium
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -17,7 +18,6 @@ spec:
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
   serviceName: observatorium-xyz-loki-ruler
   template:
     metadata:
@@ -65,7 +65,7 @@ spec:
         name: observatorium-xyz-loki-ruler
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
         - containerPort: 7946
@@ -74,7 +74,6 @@ spec:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
@@ -87,16 +86,25 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+        - mountPath: /tmp/rules
+          name: rules
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+      - configMap:
+          name: observatorium-xyz-loki-rules
+        name: rules
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-compactor-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
@@ -58,15 +59,15 @@ spec:
         name: observatorium-xyz-loki-compactor
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
-          initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
           limits:
@@ -78,16 +79,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-index-gateway-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki
         app.kubernetes.io/part-of: observatorium
+        loki.grafana.com/gossip: "true"
     spec:
       containers:
       - args:
@@ -58,15 +59,15 @@ spec:
         name: observatorium-xyz-loki-index-gateway
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
-          initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
           limits:
@@ -78,16 +79,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ingester-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -17,7 +18,6 @@ spec:
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
   serviceName: observatorium-xyz-loki-ingester
   template:
     metadata:
@@ -60,7 +60,7 @@ spec:
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
         - containerPort: 7946
@@ -69,7 +69,6 @@ spec:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
@@ -82,16 +81,21 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+      securityContext:
+        fsGroup: 10001
+      terminationGracePeriodSeconds: 4800
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki

--- a/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
+++ b/configuration/examples/local/manifests/observatorium/loki-ruler-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-loki-ruler
   namespace: observatorium
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -17,7 +18,6 @@ spec:
       app.kubernetes.io/instance: observatorium-xyz
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
-      loki.grafana.com/gossip: "true"
   serviceName: observatorium-xyz-loki-ruler
   template:
     metadata:
@@ -65,7 +65,7 @@ spec:
         name: observatorium-xyz-loki-ruler
         ports:
         - containerPort: 3100
-          name: metrics
+          name: http-metrics
         - containerPort: 9095
           name: grpc
         - containerPort: 7946
@@ -74,7 +74,6 @@ spec:
           httpGet:
             path: /ready
             port: 3100
-            scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
@@ -87,16 +86,25 @@ spec:
         volumeMounts:
         - mountPath: /etc/loki/config/
           name: config
-          readOnly: false
         - mountPath: /data
           name: storage
-          readOnly: false
+        - mountPath: /tmp/rules
+          name: rules
+      securityContext:
+        fsGroup: 10001
       volumes:
       - configMap:
           name: observatorium-xyz-loki
         name: config
+      - configMap:
+          name: observatorium-xyz-loki-rules
+        name: rules
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       labels:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: loki


### PR DESCRIPTION
# Changes

For each statefulset component we can now:
-  use the `components` struct to specify the `pvcSize`
-  use the `components` struct to specify overwrites to liveness and readiness Probes 

### Common to all components (compactor, index gateway, ingester and ruler)
- updateStrategy now set to `RollingUpdate`, shouldn't be a problem since this is the default.
- securityContext now set to `10001`, since  we were using loki images I'm suspecting this will also not be a problem 

### Compactor & Ingex Gateway
- has gossip label at the `spec.template.metadata.labels` level, before it didn't

### Ingester
- podManagementPolicy is set to `Parallel` seems like something we want https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management
- no gossip label not set at `spec.selector.matchLabels`
- terminationGracePeriodSeconds is set to 4800 (1h20min)

### Ruler 
- podManagementPolicy is set to `Parallel` seems like something we want https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management
- no gossip label not set at `spec.selector.matchLabels`