### PR TITLE
Gubernator peer discovery 

### DIFF
--- a/configuration/components/gubernator.libsonnet
+++ b/configuration/components/gubernator.libsonnet
@@ -95,6 +95,7 @@ function(params) {
       labels: gubernator.config.commonLabels,
     },
     spec: {
+      clusterIP: 'None',
       ports: [
         {
           assert std.isString(name),

--- a/configuration/components/gubernator.libsonnet
+++ b/configuration/components/gubernator.libsonnet
@@ -122,6 +122,7 @@ function(params) {
         { name: 'GUBER_GRPC_ADDRESS', value: '0.0.0.0:%s' % gubernator.config.ports.grpc },
         { name: 'GUBER_K8S_POD_PORT', value: std.toString(gubernator.config.ports.grpc) },
         { name: 'GUBER_K8S_ENDPOINTS_SELECTOR', value: 'app.kubernetes.io/name=gubernator' },
+        { name: 'GUBER_PEER_DISCOVERY_TYPE', value: 'k8s' },
       ],
       ports: [
         { name: port.name, containerPort: port.port }

--- a/configuration/examples/base/manifests/observatorium/gubernator-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/gubernator-deployment.yaml
@@ -48,6 +48,8 @@ spec:
           value: "8081"
         - name: GUBER_K8S_ENDPOINTS_SELECTOR
           value: app.kubernetes.io/name=gubernator
+        - name: GUBER_PEER_DISCOVERY_TYPE
+          value: k8s
         image: ghcr.io/mailgun/gubernator:v2.0.0-rc.36
         imagePullPolicy: IfNotPresent
         name: gubernator

--- a/configuration/examples/base/manifests/observatorium/gubernator-service.yaml
+++ b/configuration/examples/base/manifests/observatorium/gubernator-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-gubernator
   namespace: observatorium
 spec:
+  clusterIP: None
   ports:
   - name: grpc
     port: 8081

--- a/configuration/examples/dev/manifests/observatorium/gubernator-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/gubernator-deployment.yaml
@@ -48,6 +48,8 @@ spec:
           value: "8081"
         - name: GUBER_K8S_ENDPOINTS_SELECTOR
           value: app.kubernetes.io/name=gubernator
+        - name: GUBER_PEER_DISCOVERY_TYPE
+          value: k8s
         image: ghcr.io/mailgun/gubernator:v2.0.0-rc.36
         imagePullPolicy: IfNotPresent
         name: gubernator

--- a/configuration/examples/dev/manifests/observatorium/gubernator-service.yaml
+++ b/configuration/examples/dev/manifests/observatorium/gubernator-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-gubernator
   namespace: observatorium
 spec:
+  clusterIP: None
   ports:
   - name: grpc
     port: 8081

--- a/configuration/examples/local/manifests/observatorium/gubernator-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/gubernator-deployment.yaml
@@ -48,6 +48,8 @@ spec:
           value: "8081"
         - name: GUBER_K8S_ENDPOINTS_SELECTOR
           value: app.kubernetes.io/name=gubernator
+        - name: GUBER_PEER_DISCOVERY_TYPE
+          value: k8s
         image: ghcr.io/mailgun/gubernator:v2.0.0-rc.36
         imagePullPolicy: IfNotPresent
         name: gubernator

--- a/configuration/examples/local/manifests/observatorium/gubernator-service.yaml
+++ b/configuration/examples/local/manifests/observatorium/gubernator-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: observatorium-xyz-gubernator
   namespace: observatorium
 spec:
+  clusterIP: None
   ports:
   - name: grpc
     port: 8081


### PR DESCRIPTION
This change ensures we use the correct peer discovery mechanism by specifying the `GUBER_PEER_DISCOVERY_TYPE ` env var.

It also changes the Service to a headless one to ensure we can load balance between peers.