### PR TITLE
Remove Matthias Loibl (metalmatze) as maintainer

### DIFF
--- a/docs/community/maintainers.md
+++ b/docs/community/maintainers.md
@@ -8,7 +8,6 @@
 | Frederic Branczyk   | fbranczyk@gmail.com     | `@brancz`            | [@brancz](https://github.com/brancz)             | Polar Signals |
 | Kemal Akkoyun       | kakkoyun@gmail.com      | `@kakkoyun`          | [@kakkoyun](https://github.com/kakkoyun)         | Polar Signals |
 | Lucas Servén Marín  | lserven@gmail.com       | `@squat`             | [@squat](https://github.com/squat)               | Unaffiliated  |
-| Matthias Loibl      | mail@matthiasloibl.com  | `@metalmatze`        | [@metalmatze](https://github.com/metalmatze)     | Polar Signals |
 | Periklis Tsirakidis | periklis@nefeli.eu      | `@periklis`          | [@periklis](https://github.com/periklis)         | Red Hat       |
 | Prem Saraswat       | prmsrswt@gmail.com      | `@Prem Saraswat`     | [@onprem](https://github.com/onprem)             | Red Hat       |
 | Matej Gera          | matejgera@gmail.com     | `@Matej Gera`        | [@matej-g](https://github.com/matej-g)           | Red Hat       |


### PR DESCRIPTION
As per mailing list announcement. 