### PR TITLE
Add disjointed relabel configurator for compactor in go configuration

### DIFF
--- a/configuration_go/abstr/kubernetes/thanos/compactor/relabel.go
+++ b/configuration_go/abstr/kubernetes/thanos/compactor/relabel.go
@@ -1,0 +1,78 @@
+package compactor
+
+import (
+	"fmt"
+	"strings"
+
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+// MakeDisjointRelabelConfigForGroups returns a list of RelabelConfig for each group that ensures the action "keep" is applied to all label values within the group.
+// It returns an error if a label value is duplicated across multiple groups.
+// This function helps generate disjoint relabel configurations, ensuring each compactor only processes blocks from its designated group.
+// For instance, in a multitenant setup using a shared object storage bucket where different tenants require varying retention periods,
+// this function can craft the necessary relabel configurations for each compactor.
+// You must use a label that is propagated to the blocks, like an external label.
+func MakeDisjointRelabelConfigForGroups(labelName string, groups map[string][]string, maxCfgSize int) (map[string][]monv1.RelabelConfig, error) {
+	ret := make(map[string][]monv1.RelabelConfig, len(groups))
+
+	if maxCfgSize <= 0 {
+		maxCfgSize = 1
+	}
+
+	if err := checkLabelValuesUnicity(groups); err != nil {
+		return nil, err
+	}
+
+	if len(groups) == 0 {
+		return ret, nil
+	}
+
+	addRelabelConfig := func(group string, labelValues []string) {
+		if len(labelValues) == 0 {
+			return
+		}
+
+		var valuesRegex strings.Builder
+		valuesRegex.WriteString("'" + labelValues[0] + "'")
+
+		for _, value := range labelValues[1:] {
+			valuesRegex.WriteString("|'" + value + "'")
+		}
+
+		ret[group] = append(ret[group], monv1.RelabelConfig{
+			Action:       "keep",
+			SourceLabels: []monv1.LabelName{monv1.LabelName(labelName)},
+			Regex:        valuesRegex.String(),
+		})
+	}
+
+	for group, labelValues := range groups {
+		for i := 0; i < len(labelValues); i += maxCfgSize {
+			end := i + maxCfgSize
+			if end > len(labelValues) {
+				end = len(labelValues)
+			}
+
+			addRelabelConfig(group, labelValues[i:end])
+		}
+	}
+
+	return ret, nil
+}
+
+func checkLabelValuesUnicity(groups map[string][]string) error {
+	seen := make(map[string]struct{}, len(groups))
+
+	for group, labelValues := range groups {
+		for _, value := range labelValues {
+			if _, ok := seen[value]; ok {
+				return fmt.Errorf("label value %q is duplicated in group %q", value, group)
+			}
+
+			seen[value] = struct{}{}
+		}
+	}
+
+	return nil
+}

--- a/configuration_go/abstr/kubernetes/thanos/compactor/relabel_test.go
+++ b/configuration_go/abstr/kubernetes/thanos/compactor/relabel_test.go
@@ -1,0 +1,143 @@
+package compactor_test
+
+import (
+	"testing"
+
+	"github.com/observatorium/observatorium/configuration_go/abstr/kubernetes/thanos/compactor"
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func TestMakeDisjointRelabelConfigForGroups(t *testing.T) {
+	labelName := monv1.LabelName("mylabel")
+
+	makeRelabelCfg := func(regex string) monv1.RelabelConfig {
+		return monv1.RelabelConfig{
+			Action:       "keep",
+			SourceLabels: []monv1.LabelName{labelName},
+			Regex:        regex,
+		}
+	}
+
+	testCases := map[string]struct {
+		groups     map[string][]string
+		maxCfgSize int
+		expect     map[string][]monv1.RelabelConfig
+		expectErr  bool
+	}{
+		"empty": {
+			groups: map[string][]string{},
+			expect: map[string][]monv1.RelabelConfig{},
+		},
+		"one group": {
+			groups: map[string][]string{
+				"group1": {"value1"},
+			},
+			expect: map[string][]monv1.RelabelConfig{
+				"group1": {makeRelabelCfg("'value1'")},
+			},
+		},
+		"two groups": {
+			groups: map[string][]string{
+				"group1": {"value1", "value2"},
+			},
+			expect: map[string][]monv1.RelabelConfig{
+				"group1": {
+					makeRelabelCfg("'value1'"),
+					makeRelabelCfg("'value2'"),
+				},
+			},
+		},
+		"group split": {
+			groups: map[string][]string{
+				"group1": {"value1", "value2", "value3", "value4", "value5"},
+			},
+			maxCfgSize: 2,
+			expect: map[string][]monv1.RelabelConfig{
+				"group1": {
+					makeRelabelCfg("'value1'|'value2'"),
+					makeRelabelCfg("'value3'|'value4'"),
+					makeRelabelCfg("'value5'"),
+				},
+			},
+		},
+
+		"duplicated label value": {
+			groups: map[string][]string{
+				"group1": {"value1", "value1"},
+			},
+			expectErr: true,
+		},
+		"duplicated label value in different groups": {
+			groups: map[string][]string{
+				"group1": {"value1"},
+				"group2": {"value1"},
+			},
+			expectErr: true,
+		},
+		"multi groups": {
+			groups: map[string][]string{
+				"group1": {"value1", "value2", "value3", "value4"},
+				"group2": {"value11", "value12", "value13"},
+			},
+			maxCfgSize: 2,
+			expect: map[string][]monv1.RelabelConfig{
+				"group1": {
+					makeRelabelCfg("'value1'|'value2'"),
+					makeRelabelCfg("'value3'|'value4'"),
+				},
+				"group2": {
+					makeRelabelCfg("'value11'|'value12'"),
+					makeRelabelCfg("'value13'"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := compactor.MakeDisjointRelabelConfigForGroups(string(labelName), tc.groups, tc.maxCfgSize)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				return
+			}
+
+			if len(got) != len(tc.expect) {
+				t.Fatalf("expected %d relabel configs, got %d", len(tc.expect), len(got))
+			}
+
+			for group, expect := range tc.expect {
+				got, ok := got[group]
+				if !ok {
+					t.Fatalf("expected relabel config for group %q", group)
+				}
+
+				if len(got) != len(expect) {
+					t.Fatalf("expected %d relabel configs for group %q, got %d", len(expect), group, len(got))
+				}
+
+				for i := range expect {
+					if got[i].Regex != expect[i].Regex {
+						t.Fatalf("expected regex %q, got %q", expect[i].Regex, got[i].Regex)
+					}
+
+					if got[i].Action != expect[i].Action {
+						t.Fatalf("expected action %q, got %q", expect[i].Action, got[i].Action)
+					}
+
+					if len(got[i].SourceLabels) != len(expect[i].SourceLabels) {
+						t.Fatalf("expected %d source labels, got %d", len(expect[i].SourceLabels), len(got[i].SourceLabels))
+					}
+
+					for j := range expect[i].SourceLabels {
+						if got[i].SourceLabels[j] != expect[i].SourceLabels[j] {
+							t.Fatalf("expected source label %q, got %q", expect[i].SourceLabels[j], got[i].SourceLabels[j])
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This helps generating relabel configurations in soft tenancy environments for example.
I think it can be useful in this repo. Let me know what you think.