### PR TITLE
Go configs: Add memcached deployment and bucket cache config

### DIFF
--- a/configuration_go/abstr/kubernetes/memcached/memcached.go
+++ b/configuration_go/abstr/kubernetes/memcached/memcached.go
@@ -1,0 +1,212 @@
+package memcached
+
+import (
+	"fmt"
+
+	cmdopt "github.com/observatorium/observatorium/configuration_go/abstr/kubernetes/cmdoption"
+	"github.com/observatorium/observatorium/configuration_go/k8sutil"
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultPort         = 11211
+	dataVolumeName      = "data"
+	exporterDefaultPort = 9150
+)
+
+// MemcachedOptions is the options for the memcached container.
+type MemcachedOptions struct {
+	ConnLimit       int    `opt:"conn-limit"`
+	ListenBacklog   int    `opt:"listen-backlog"`
+	MaxItemSize     string `opt:"max-item-size"`
+	MaxReqsPerEvent int    `opt:"max-reqs-per-event"`
+	MemoryLimit     int    `opt:"memory-limit"`
+	Port            int    `opt:"port"`
+	Threads         int    `opt:"threads"`
+	Verbose         bool   `opt:"verbose"`
+	VeryVerbose     bool   `opt:"vv,single-hyphen"`
+
+	// Extra options not included above.
+	cmdopt.ExtraOpts
+}
+
+// MemcachedDeployment is the memcached deployment.
+type MemcachedDeployment struct {
+	Options *MemcachedOptions
+	k8sutil.DeploymentGenericConfig
+	ExporterImage    string
+	ExporterImageTag string
+}
+
+// NewMemcachedStatefulSet returns a new memcached deployment.
+func NewMemcachedStatefulSet() *MemcachedDeployment {
+	options := MemcachedOptions{}
+
+	commonLabels := map[string]string{
+		k8sutil.NameLabel:      "memcached",
+		k8sutil.InstanceLabel:  "observatorium",
+		k8sutil.PartOfLabel:    "observatorium",
+		k8sutil.ComponentLabel: "memcached",
+	}
+
+	labelSelectors := map[string]string{
+		k8sutil.NameLabel:     commonLabels[k8sutil.NameLabel],
+		k8sutil.InstanceLabel: commonLabels[k8sutil.InstanceLabel],
+	}
+
+	genericDeployment := k8sutil.DeploymentGenericConfig{
+		Name:                          "memcached",
+		Image:                         "docker.io/memcached",
+		ImageTag:                      "latest",
+		ImagePullPolicy:               corev1.PullIfNotPresent,
+		CommonLabels:                  commonLabels,
+		Replicas:                      1,
+		Env:                           []corev1.EnvVar{},
+		PodResources:                  k8sutil.NewResourcesRequirements("500m", "3", "2Gi", "3Gi"),
+		Affinity:                      *k8sutil.NewAntiAffinity(nil, labelSelectors),
+		EnableServiceMonitor:          true,
+		TerminationGracePeriodSeconds: 120,
+		SecurityContext:               k8sutil.GetDefaultSecurityContext(),
+		ConfigMaps:                    map[string]map[string]string{},
+		Secrets:                       map[string]map[string][]byte{},
+	}
+
+	return &MemcachedDeployment{
+		Options:                 &options,
+		DeploymentGenericConfig: genericDeployment,
+		ExporterImage:           "quay.io/prometheus/memcached-exporter",
+		ExporterImageTag:        "latest",
+	}
+}
+
+// Manifests returns the manifests for the memcached deployment.
+func (s *MemcachedDeployment) Manifests() k8sutil.ObjectMap {
+	container := s.makeContainer()
+
+	commonObjectMeta := k8sutil.MetaConfig{
+		Name:      s.Name,
+		Labels:    s.CommonLabels,
+		Namespace: s.Namespace,
+	}
+	commonObjectMeta.Labels[k8sutil.VersionLabel] = container.ImageTag
+
+	pod := &k8sutil.Pod{
+		TerminationGracePeriodSeconds: &s.TerminationGracePeriodSeconds,
+		Affinity:                      &s.Affinity,
+		SecurityContext:               s.SecurityContext,
+		ServiceAccountName:            commonObjectMeta.Name,
+		ContainerProviders:            append([]k8sutil.ContainerProvider{container, s.makeExporterContainer()}, s.Sidecars...),
+	}
+
+	deployment := &k8sutil.Deployment{
+		MetaConfig: commonObjectMeta.Clone(),
+		Replicas:   s.Replicas,
+		Pod:        pod,
+	}
+
+	ret := k8sutil.ObjectMap{
+		"memcached-deployment": deployment.MakeManifest(),
+	}
+
+	service := &k8sutil.Service{
+		MetaConfig:   commonObjectMeta.Clone(),
+		ServicePorts: pod,
+		// As memcached is deployed as a deployment, we use a headless service.
+		// Combined with DNS discovery, this ensures direct access to the pods.
+		ClusterIP: "None",
+	}
+	ret["memcached-service"] = service.MakeManifest()
+
+	if s.EnableServiceMonitor {
+		serviceMonitor := &k8sutil.ServiceMonitor{
+			MetaConfig:              commonObjectMeta.Clone(),
+			ServiceMonitorEndpoints: pod,
+		}
+		ret["memcached-serviceMonitor"] = serviceMonitor.MakeManifest()
+	}
+
+	serviceAccount := &k8sutil.ServiceAccount{
+		MetaConfig: commonObjectMeta.Clone(),
+		Name:       pod.ServiceAccountName,
+	}
+	ret["memcached-serviceAccount"] = serviceAccount.MakeManifest()
+
+	// Create configMaps required by the containers
+	for name, config := range pod.GetConfigMaps() {
+		configMap := &k8sutil.ConfigMap{
+			MetaConfig: commonObjectMeta.Clone(),
+			Data:       config,
+		}
+		configMap.MetaConfig.Name = name
+		ret["memcached-configMap-"+name] = configMap.MakeManifest()
+	}
+
+	// Create secrets required by the containers
+	for name, secret := range pod.GetSecrets() {
+		secret := &k8sutil.Secret{
+			MetaConfig: commonObjectMeta.Clone(),
+			Data:       secret,
+		}
+		secret.MetaConfig.Name = name
+		ret["memcached-secret-"+name] = secret.MakeManifest()
+	}
+
+	return ret
+}
+
+func (s *MemcachedDeployment) makeContainer() *k8sutil.Container {
+	if s.Options == nil {
+		s.Options = &MemcachedOptions{}
+	}
+
+	httpPort := defaultPort
+	if s.Options.Port != 0 {
+		httpPort = s.Options.Port
+	}
+
+	ret := s.ToContainer()
+	ret.Args = cmdopt.GetOpts(s.Options)
+	ret.Ports = []corev1.ContainerPort{
+		{
+			Name:          "client",
+			ContainerPort: int32(httpPort),
+			Protocol:      corev1.ProtocolTCP,
+		},
+	}
+	ret.ServicePorts = []corev1.ServicePort{
+		k8sutil.NewServicePort("client", httpPort, httpPort),
+	}
+
+	return ret
+}
+
+func (s *MemcachedDeployment) makeExporterContainer() *k8sutil.Container {
+	return &k8sutil.Container{
+		Name:            "memcached-exporter",
+		Image:           s.ExporterImage,
+		ImageTag:        s.ExporterImageTag,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Resources:       k8sutil.NewResourcesRequirements("50m", "200m", "50Mi", "200Mi"),
+		Args: []string{
+			fmt.Sprintf("--memcached.address=localhost:%d", s.Options.Port),
+			fmt.Sprintf("--web.listen-address=:%d", exporterDefaultPort),
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "metrics",
+				ContainerPort: exporterDefaultPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		ServicePorts: []corev1.ServicePort{
+			k8sutil.NewServicePort("metrics", exporterDefaultPort, exporterDefaultPort),
+		},
+		MonitorPorts: []monv1.Endpoint{
+			{
+				Port:           "metrics",
+				RelabelConfigs: k8sutil.GetDefaultServiceMonitorRelabelConfig(),
+			},
+		},
+	}
+}

--- a/configuration_go/abstr/kubernetes/memcached/memcached.go
+++ b/configuration_go/abstr/kubernetes/memcached/memcached.go
@@ -64,7 +64,7 @@ func NewMemcachedStatefulSet() *MemcachedDeployment {
 		Replicas:                      1,
 		Env:                           []corev1.EnvVar{},
 		PodResources:                  k8sutil.NewResourcesRequirements("500m", "3", "2Gi", "3Gi"),
-		Affinity:                      *k8sutil.NewAntiAffinity(nil, labelSelectors),
+		Affinity:                      k8sutil.NewAntiAffinity(nil, labelSelectors),
 		EnableServiceMonitor:          true,
 		TerminationGracePeriodSeconds: 120,
 		SecurityContext:               k8sutil.GetDefaultSecurityContext(),
@@ -93,7 +93,7 @@ func (s *MemcachedDeployment) Manifests() k8sutil.ObjectMap {
 
 	pod := &k8sutil.Pod{
 		TerminationGracePeriodSeconds: &s.TerminationGracePeriodSeconds,
-		Affinity:                      &s.Affinity,
+		Affinity:                      s.Affinity,
 		SecurityContext:               s.SecurityContext,
 		ServiceAccountName:            commonObjectMeta.Name,
 		ContainerProviders:            append([]k8sutil.ContainerProvider{container, s.makeExporterContainer()}, s.Sidecars...),

--- a/configuration_go/abstr/kubernetes/observatoriumapi/api.go
+++ b/configuration_go/abstr/kubernetes/observatoriumapi/api.go
@@ -155,7 +155,7 @@ func NewObservatoriumAPI(opts ...ObservatoriumAPIOption) *observatoriumAPI {
 					corev1.ResourceMemory: resource.MustParse("2000Mi"),
 				},
 			},
-			Affinity: corev1.Affinity{
+			Affinity: &corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 						{
@@ -176,7 +176,7 @@ func NewObservatoriumAPI(opts ...ObservatoriumAPIOption) *observatoriumAPI {
 					},
 				},
 			},
-			LivenessProbe: corev1.Probe{
+			LivenessProbe: &corev1.Probe{
 				FailureThreshold: 10,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -187,7 +187,7 @@ func NewObservatoriumAPI(opts ...ObservatoriumAPIOption) *observatoriumAPI {
 				},
 				PeriodSeconds: 30,
 			},
-			ReadinessProbe: corev1.Probe{
+			ReadinessProbe: &corev1.Probe{
 				FailureThreshold: 12,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -198,7 +198,7 @@ func NewObservatoriumAPI(opts ...ObservatoriumAPIOption) *observatoriumAPI {
 				},
 				PeriodSeconds: 5,
 			},
-			SecurityContext: corev1.PodSecurityContext{
+			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser: &[]int64{65534}[0],
 				FSGroup:   &[]int64{65534}[0],
 			},
@@ -321,8 +321,8 @@ func (c *observatoriumAPI) Manifests(opts ...ObservatoriumAPIOption) k8sutil.Obj
 			},
 		},
 		Resources:      c.PodResources,
-		LivenessProbe:  &c.LivenessProbe,
-		ReadinessProbe: &c.ReadinessProbe,
+		LivenessProbe:  c.LivenessProbe,
+		ReadinessProbe: c.ReadinessProbe,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/etc/observatorium/rbac.yaml",
@@ -391,7 +391,7 @@ func (c *observatoriumAPI) Manifests(opts ...ObservatoriumAPIOption) k8sutil.Obj
 	pod := k8sutil.Pod{
 		ContainerProviders: containers,
 		SecurityContext:    c.SecurityContext,
-		Affinity:           &c.Affinity,
+		Affinity:           c.Affinity,
 		ServiceAccountName: apiServiceAccount.Name,
 	}
 

--- a/configuration_go/abstr/kubernetes/thanos/compactor/compactor.go
+++ b/configuration_go/abstr/kubernetes/thanos/compactor/compactor.go
@@ -117,7 +117,7 @@ func NewCompactor() *CompactorStatefulSet {
 			CommonLabels:         commonLabels,
 			Replicas:             1,
 			PodResources:         k8sutil.NewResourcesRequirements("2", "3", "2000Mi", "3000Mi"),
-			Affinity:             *k8sutil.NewAntiAffinity(nil, labelSelectors),
+			Affinity:             k8sutil.NewAntiAffinity(nil, labelSelectors),
 			EnableServiceMonitor: true,
 			LivenessProbe: k8sutil.NewProbe("/-/healthy", defaultHTTPPort, k8sutil.ProbeConfig{
 				FailureThreshold: 4,
@@ -154,7 +154,7 @@ func (c *CompactorStatefulSet) Manifests() k8sutil.ObjectMap {
 
 	pod := &k8sutil.Pod{
 		TerminationGracePeriodSeconds: &c.TerminationGracePeriodSeconds,
-		Affinity:                      &c.Affinity,
+		Affinity:                      c.Affinity,
 		SecurityContext:               c.SecurityContext,
 		ServiceAccountName:            commonObjectMeta.Name,
 		ContainerProviders:            append([]k8sutil.ContainerProvider{container}, c.Sidecars...),

--- a/configuration_go/abstr/kubernetes/thanos/query/query.go
+++ b/configuration_go/abstr/kubernetes/thanos/query/query.go
@@ -477,7 +477,7 @@ func NewThanosQuery(opts ...ThanosQueryOption) *query {
 					corev1.ResourceMemory: resource.MustParse("3Gi"),
 				},
 			},
-			Affinity: corev1.Affinity{
+			Affinity: &corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 						{
@@ -498,7 +498,7 @@ func NewThanosQuery(opts ...ThanosQueryOption) *query {
 					},
 				},
 			},
-			LivenessProbe: corev1.Probe{
+			LivenessProbe: &corev1.Probe{
 				FailureThreshold: 4,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -509,7 +509,7 @@ func NewThanosQuery(opts ...ThanosQueryOption) *query {
 				},
 				PeriodSeconds: 30,
 			},
-			ReadinessProbe: corev1.Probe{
+			ReadinessProbe: &corev1.Probe{
 				FailureThreshold: 20,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -520,7 +520,7 @@ func NewThanosQuery(opts ...ThanosQueryOption) *query {
 				},
 				PeriodSeconds: 5,
 			},
-			SecurityContext: corev1.PodSecurityContext{
+			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser: &[]int64{65534}[0],
 				FSGroup:   &[]int64{65534}[0],
 			},
@@ -697,8 +697,8 @@ func (q *query) Manifests(opts ...ThanosQueryOption) k8sutil.ObjectMap {
 			},
 		},
 		Resources:      q.PodResources,
-		LivenessProbe:  &q.LivenessProbe,
-		ReadinessProbe: &q.ReadinessProbe,
+		LivenessProbe:  q.LivenessProbe,
+		ReadinessProbe: q.ReadinessProbe,
 		ServicePorts: []corev1.ServicePort{
 			{
 				AppProtocol: &[]string{"h2c"}[0],
@@ -759,7 +759,7 @@ func (q *query) Manifests(opts ...ThanosQueryOption) k8sutil.ObjectMap {
 	pod := k8sutil.Pod{
 		ContainerProviders: containers,
 		SecurityContext:    q.SecurityContext,
-		Affinity:           &q.Affinity,
+		Affinity:           q.Affinity,
 		ServiceAccountName: queryServiceAccount.Name,
 	}
 

--- a/configuration_go/abstr/kubernetes/thanos/receive/controller.go
+++ b/configuration_go/abstr/kubernetes/thanos/receive/controller.go
@@ -2,6 +2,7 @@ package receive
 
 import (
 	"fmt"
+	"strings"
 
 	cmdopt "github.com/observatorium/observatorium/configuration_go/abstr/kubernetes/cmdoption"
 	"github.com/observatorium/observatorium/configuration_go/k8sutil"
@@ -88,11 +89,11 @@ func (c *Controller) Manifests() k8sutil.ObjectMap {
 
 	ret["controller-deployment"] = deployment.MakeManifest()
 
-	service := &k8sutil.Service{
-		MetaConfig:   commonObjectMeta.Clone(),
-		ServicePorts: pod,
-	}
-	ret["controller-service"] = service.MakeManifest()
+	// service := &k8sutil.Service{
+	// 	MetaConfig:   commonObjectMeta.Clone(),
+	// 	ServicePorts: pod,
+	// }
+	// ret["controller-service"] = service.MakeManifest()
 
 	if c.EnableServiceMonitor {
 		serviceMonitor := &k8sutil.ServiceMonitor{
@@ -157,6 +158,7 @@ func (c *Controller) Manifests() k8sutil.ObjectMap {
 	}
 
 	// create role binding
+	apiGroup := strings.Split(k8sutil.RoleMeta.APIVersion, "/")[0]
 	ret["controller-rolebinding"] = &rbacv1.RoleBinding{
 		TypeMeta: k8sutil.RoleBindingMeta,
 		ObjectMeta: metav1.ObjectMeta{
@@ -174,7 +176,7 @@ func (c *Controller) Manifests() k8sutil.ObjectMap {
 		RoleRef: rbacv1.RoleRef{
 			Kind:     k8sutil.RoleMeta.Kind,
 			Name:     c.Name,
-			APIGroup: k8sutil.RoleMeta.APIVersion,
+			APIGroup: apiGroup,
 		},
 	}
 

--- a/configuration_go/abstr/kubernetes/thanos/receive/receive.go
+++ b/configuration_go/abstr/kubernetes/thanos/receive/receive.go
@@ -281,7 +281,7 @@ func newBaseReceive(commonLabels map[string]string) *baseReceive {
 			CommonLabels:         commonLabels,
 			Replicas:             1,
 			PodResources:         k8sutil.NewResourcesRequirements("1", "2", "10Gi", "20Gi"),
-			Affinity:             *k8sutil.NewAntiAffinity(nil, labelSelectors),
+			Affinity:             k8sutil.NewAntiAffinity(nil, labelSelectors),
 			EnableServiceMonitor: true,
 			LivenessProbe: k8sutil.NewProbe("/-/healthy", defaultHTTPPort, k8sutil.ProbeConfig{
 				FailureThreshold: 8,
@@ -384,7 +384,7 @@ func (br *baseReceive) manifests() k8sutil.ObjectMap {
 
 	pod := &k8sutil.Pod{
 		TerminationGracePeriodSeconds: &br.TerminationGracePeriodSeconds,
-		Affinity:                      &br.Affinity,
+		Affinity:                      br.Affinity,
 		SecurityContext:               br.SecurityContext,
 		ServiceAccountName:            commonObjectMeta.Name,
 		ContainerProviders:            append([]k8sutil.ContainerProvider{container}, br.Sidecars...),

--- a/configuration_go/abstr/kubernetes/thanos/store/store.go
+++ b/configuration_go/abstr/kubernetes/thanos/store/store.go
@@ -118,7 +118,7 @@ func NewStore() *StoreStatefulSet {
 			CommonLabels:         commonLabels,
 			Replicas:             1,
 			PodResources:         k8sutil.NewResourcesRequirements("500m", "1", "200Mi", "400Mi"),
-			Affinity:             *k8sutil.NewAntiAffinity(nil, labelSelectors),
+			Affinity:             k8sutil.NewAntiAffinity(nil, labelSelectors),
 			EnableServiceMonitor: true,
 
 			LivenessProbe: k8sutil.NewProbe("/-/healthy", defaultHTTPPort, k8sutil.ProbeConfig{
@@ -154,7 +154,7 @@ func (s *StoreStatefulSet) Manifests() k8sutil.ObjectMap {
 
 	pod := &k8sutil.Pod{
 		TerminationGracePeriodSeconds: &s.TerminationGracePeriodSeconds,
-		Affinity:                      &s.Affinity,
+		Affinity:                      s.Affinity,
 		SecurityContext:               s.SecurityContext,
 		ServiceAccountName:            commonObjectMeta.Name,
 		ContainerProviders:            append([]k8sutil.ContainerProvider{container}, s.Sidecars...),

--- a/configuration_go/k8sutil/genericdeployment.go
+++ b/configuration_go/k8sutil/genericdeployment.go
@@ -20,12 +20,12 @@ type DeploymentGenericConfig struct {
 	Replicas             int32
 	DeploymentStrategy   appsv1.DeploymentStrategy // Only applies to Deployment kind
 	PodResources         corev1.ResourceRequirements
-	Affinity             corev1.Affinity
-	SecurityContext      corev1.PodSecurityContext
+	Affinity             *corev1.Affinity
+	SecurityContext      *corev1.PodSecurityContext
 	EnableServiceMonitor bool
 	Env                  []corev1.EnvVar
-	LivenessProbe        corev1.Probe
-	ReadinessProbe       corev1.Probe
+	LivenessProbe        *corev1.Probe
+	ReadinessProbe       *corev1.Probe
 
 	// Pod fields
 	TerminationMessagePolicy      corev1.TerminationMessagePolicy
@@ -46,8 +46,8 @@ func (d DeploymentGenericConfig) ToContainer() *Container {
 		ImagePullPolicy: d.ImagePullPolicy,
 		Env:             d.Env,
 		Resources:       d.PodResources,
-		LivenessProbe:   &d.LivenessProbe,
-		ReadinessProbe:  &d.ReadinessProbe,
+		LivenessProbe:   d.LivenessProbe,
+		ReadinessProbe:  d.ReadinessProbe,
 		ConfigMaps:      d.ConfigMaps,
 		Secrets:         d.Secrets,
 	}
@@ -114,14 +114,14 @@ func WithResources(resource corev1.ResourceRequirements) DeploymentOption {
 }
 
 // WithAffinity overrides the default Pod scheduling affinity rules.
-func WithAffinity(affinity corev1.Affinity) DeploymentOption {
+func WithAffinity(affinity *corev1.Affinity) DeploymentOption {
 	return func(d *DeploymentGenericConfig) {
 		d.Affinity = affinity
 	}
 }
 
 // WithSecurityContext overrides the default Pod security context.
-func WithSecurityContext(sc corev1.PodSecurityContext) DeploymentOption {
+func WithSecurityContext(sc *corev1.PodSecurityContext) DeploymentOption {
 	return func(d *DeploymentGenericConfig) {
 		d.SecurityContext = sc
 	}
@@ -135,7 +135,7 @@ func WithServiceMonitor() DeploymentOption {
 }
 
 // WithProbe overrides the default K8s liveness and readiness probes of main deployment container.
-func WithProbes(livenessProbe, readinessProbe corev1.Probe) DeploymentOption {
+func WithProbes(livenessProbe, readinessProbe *corev1.Probe) DeploymentOption {
 	return func(d *DeploymentGenericConfig) {
 		d.LivenessProbe = livenessProbe
 		d.ReadinessProbe = readinessProbe

--- a/configuration_go/k8sutil/providers.go
+++ b/configuration_go/k8sutil/providers.go
@@ -201,7 +201,7 @@ type PodProvider interface {
 type Pod struct {
 	TerminationGracePeriodSeconds *int64
 	Affinity                      *corev1.Affinity
-	SecurityContext               corev1.PodSecurityContext
+	SecurityContext               *corev1.PodSecurityContext
 	ServiceAccountName            string
 
 	ContainerProviders []ContainerProvider
@@ -222,7 +222,7 @@ func (p *Pod) MakePodSpec() corev1.PodSpec {
 		Affinity:                      p.Affinity,
 		Containers:                    containers,
 		ServiceAccountName:            p.ServiceAccountName,
-		SecurityContext:               &p.SecurityContext,
+		SecurityContext:               p.SecurityContext,
 		NodeSelector: map[string]string{
 			OsLabel: LinuxOs,
 		},

--- a/configuration_go/k8sutil/providers.go
+++ b/configuration_go/k8sutil/providers.go
@@ -373,6 +373,7 @@ type ServiceProvider interface {
 type Service struct {
 	MetaConfig
 	ServicePorts ServiceProvider
+	ClusterIP    string
 }
 
 // NewService returns a new Service.
@@ -392,8 +393,9 @@ func (s *Service) MakeManifest() runtime.Object {
 		TypeMeta:   ServiceMeta,
 		ObjectMeta: s.MetaConfig.MakeMeta(),
 		Spec: corev1.ServiceSpec{
-			Ports:    s.ServicePorts.GetServicePorts(),
-			Selector: selector,
+			Ports:     s.ServicePorts.GetServicePorts(),
+			Selector:  selector,
+			ClusterIP: s.ClusterIP,
 		},
 	}
 }

--- a/configuration_go/k8sutil/utils.go
+++ b/configuration_go/k8sutil/utils.go
@@ -23,9 +23,9 @@ func GetDefaultServiceMonitorRelabelConfig() []*monv1.RelabelConfig {
 }
 
 // GetDefaultSecurityContext returns the default security context for a container.
-func GetDefaultSecurityContext() corev1.PodSecurityContext {
+func GetDefaultSecurityContext() *corev1.PodSecurityContext {
 	val := int64(65534)
-	return corev1.PodSecurityContext{
+	return &corev1.PodSecurityContext{
 		RunAsUser: &val,
 		FSGroup:   &val,
 	}
@@ -63,8 +63,8 @@ type ProbeConfig struct {
 }
 
 // NewProbe returns a new probe.
-func NewProbe(path string, port int, cfg ProbeConfig) corev1.Probe {
-	return corev1.Probe{
+func NewProbe(path string, port int, cfg ProbeConfig) *corev1.Probe {
+	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: path,

--- a/configuration_go/schemas/thanos/cache/cache.go
+++ b/configuration_go/schemas/thanos/cache/cache.go
@@ -7,7 +7,6 @@ import (
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/cache/memcached"
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/cache/memory"
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/cache/redis"
-	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/units"
 	"gopkg.in/yaml.v2"
 )
 
@@ -72,7 +71,7 @@ type BucketCacheConfig struct {
 	// Maximum number of GetRange requests issued by this bucket for single GetRange call. Zero or negative value = unlimited.
 	MaxChunksGetRangeRequests int `yaml:"max_chunks_get_range_requests,omitempty"`
 
-	MetafileMaxSize units.Bytes `yaml:"metafile_max_size,omitempty"`
+	MetafileMaxSize string `yaml:"metafile_max_size,omitempty"`
 
 	// TTLs for various cache items.
 	ChunkObjectAttrsTTL time.Duration `yaml:"chunk_object_attrs_ttl,omitempty"`

--- a/configuration_go/schemas/thanos/cache/cache.go
+++ b/configuration_go/schemas/thanos/cache/cache.go
@@ -2,17 +2,32 @@ package cache
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/cache/memcached"
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/cache/memory"
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/cache/redis"
+	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/units"
 	"gopkg.in/yaml.v2"
+)
+
+type IndexCacheEnabledItem string
+
+const (
+	Postings         IndexCacheEnabledItem = "Postings"
+	Series           IndexCacheEnabledItem = "Series"
+	ExpandedPostings IndexCacheEnabledItem = "ExpandedPostings"
 )
 
 // IndexCacheConfig specifies the index cache config.
 type IndexCacheConfig struct {
 	ConfigType string      `yaml:"type"`
 	Config     interface{} `yaml:"config"`
+	// Available item types are Postings, Series and ExpandedPostings.
+	EnabledItems []IndexCacheEnabledItem `yaml:"enabled_items,omitempty"`
+	// TTL for storing items in remote cache. Not supported for inmemory cache.
+	// Default value is 24h.
+	TTL time.Duration `yaml:"ttl,omitempty"`
 }
 
 // String returns a string representation of the IndexCacheConfig as YAML.
@@ -30,9 +45,54 @@ type CacheConfig interface {
 	Type() string
 }
 
-func NewConfig[T CacheConfig](c T) *IndexCacheConfig {
+func NewIndexCacheConfig[T CacheConfig](c T) *IndexCacheConfig {
 	return &IndexCacheConfig{
 		ConfigType: c.Type(),
 		Config:     c,
 	}
+}
+
+func NewBucketCacheConfig[T CacheConfig](c T) *BucketCacheConfig {
+	return &BucketCacheConfig{
+		Type:   c.Type(),
+		Config: c,
+	}
+}
+
+// Taken from https://github.com/thanos-io/thanos/blob/release-0.32/pkg/store/cache/caching_bucket_factory.go#L37
+
+// CachingWithBackendConfig is a configuration of caching bucket used by Store component.
+type BucketCacheConfig struct {
+	Type   string      `yaml:"type"`
+	Config interface{} `yaml:"config"`
+
+	// Basic unit used to cache chunks.
+	ChunkSubrangeSize int64 `yaml:"chunk_subrange_size,omitempty"`
+
+	// Maximum number of GetRange requests issued by this bucket for single GetRange call. Zero or negative value = unlimited.
+	MaxChunksGetRangeRequests int `yaml:"max_chunks_get_range_requests,omitempty"`
+
+	MetafileMaxSize units.Bytes `yaml:"metafile_max_size,omitempty"`
+
+	// TTLs for various cache items.
+	ChunkObjectAttrsTTL time.Duration `yaml:"chunk_object_attrs_ttl,omitempty"`
+	ChunkSubrangeTTL    time.Duration `yaml:"chunk_subrange_ttl,omitempty"`
+
+	// How long to cache result of Iter call in root directory.
+	BlocksIterTTL time.Duration `yaml:"blocks_iter_ttl,omitempty"`
+
+	// Config for Exists and Get operations for metadata files.
+	MetafileExistsTTL      time.Duration `yaml:"metafile_exists_ttl,omitempty"`
+	MetafileDoesntExistTTL time.Duration `yaml:"metafile_doesnt_exist_ttl,omitempty"`
+	MetafileContentTTL     time.Duration `yaml:"metafile_content_ttl,omitempty"`
+}
+
+// String returns a string representation of the BucketCacheConfig as YAML.
+// We use "gopkg.in/yaml.v2" instead of "github.com/ghodss/yaml" for correct formatting of this config.
+func (c BucketCacheConfig) String() string {
+	ret, err := yaml.Marshal(c)
+	if err != nil {
+		panic(fmt.Sprintf("error mashalling BucketCacheConfig to yaml: %v", err))
+	}
+	return string(ret)
 }

--- a/configuration_go/schemas/thanos/cache/memcached/memcached.go
+++ b/configuration_go/schemas/thanos/cache/memcached/memcached.go
@@ -2,8 +2,6 @@ package memcached
 
 import (
 	"time"
-
-	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/units"
 )
 
 // Taken from https://github.com/thanos-io/thanos/blob/release-0.32/pkg/cacheutil/memcached_client.go#L106
@@ -13,7 +11,7 @@ var DefaultMemcachedClientConfig = MemcachedClientConfig{
 	MaxIdleConnections:        100,
 	MaxAsyncConcurrency:       20,
 	MaxAsyncBufferSize:        10000,
-	MaxItemSize:               units.Bytes(1024 * 1024),
+	MaxItemSize:               "1MiB",
 	MaxGetMultiConcurrency:    100,
 	MaxGetMultiBatchSize:      0,
 	DNSProviderUpdateInterval: 10 * time.Second,
@@ -47,7 +45,7 @@ type MemcachedClientConfig struct {
 	// MaxItemSize specifies the maximum size of an item stored in memcached.
 	// Items bigger than MaxItemSize are skipped.
 	// If set to 0, no maximum size is enforced.
-	MaxItemSize units.Bytes `yaml:"max_item_size,omitempty"`
+	MaxItemSize string `yaml:"max_item_size,omitempty"`
 
 	// MaxGetMultiBatchSize specifies the maximum number of keys a single underlying
 	// GetMulti() should run. If more keys are specified, internally keys are splitted

--- a/configuration_go/schemas/thanos/cache/memory/memory.go
+++ b/configuration_go/schemas/thanos/cache/memory/memory.go
@@ -1,13 +1,11 @@
 package memory
 
-import "github.com/observatorium/observatorium/configuration_go/schemas/thanos/units"
-
 // Taken from https://github.com/thanos-io/thanos/blob/release-0.32/pkg/store/cache/inmemory.go#L56
 
 // InMemoryIndexCacheConfig holds the in-memory index cache config.
 type MemoryCacheConfig struct {
-	MaxSize     units.Bytes `yaml:"max_size,omitempty"`
-	MaxItemSize units.Bytes `yaml:"max_item_size,omitempty"`
+	MaxSize     string `yaml:"max_size,omitempty"`
+	MaxItemSize string `yaml:"max_item_size,omitempty"`
 }
 
 func (c MemoryCacheConfig) Type() string {

--- a/configuration_go/schemas/thanos/cache/redis/redis.go
+++ b/configuration_go/schemas/thanos/cache/redis/redis.go
@@ -2,8 +2,6 @@ package redis
 
 import (
 	"time"
-
-	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/units"
 )
 
 // Taken from https://github.com/thanos-io/thanos/blob/release-0.32/pkg/cacheutil/redis_client.go#L60
@@ -71,7 +69,7 @@ type RedisClientConfig struct {
 	// Client-side caching is when data is stored in memory
 	// instead of fetching data each time.
 	// See https://redis.io/docs/manual/client-side-caching/ for info.
-	CacheSize units.Bytes `yaml:"cache_size,omitempty"`
+	CacheSize string `yaml:"cache_size,omitempty"`
 
 	// MasterName specifies the master's name. Must be not empty
 	// for Redis Sentinel.


### PR DESCRIPTION
* Adds memcached deployments
* Sets optional k8s objects as pointers to avoid empty objects generation that causes validation issues (pod affinity, container probes, security cfg)